### PR TITLE
feat(redis,postgres): serve admin-editable command responses (fallback-safe)

### DIFF
--- a/postgres/pg.go
+++ b/postgres/pg.go
@@ -95,6 +95,16 @@ func handler(ctx context.Context, query string) (wire.PreparedStatements, error)
 		})), nil
 	}
 
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="postgres"). Postgres is binary/message-framed, so lookupServerStatement
+	// FRAMES the stored plain text: row-returning queries render as a single ("result" text)
+	// row; set/begin-style statements render as a CommandComplete tag. On miss/error/oversize
+	// it returns ok=false and we fall through to the hardcoded responses map, so behavior
+	// never regresses if the server is unreachable.
+	if stmt, ok := lookupServerStatement(query); ok {
+		return stmt, nil
+	}
+
 	resp, ok := responses[query]
 	//litter.Dump(wire.ClientParameters(ctx))
 	//litter.Dump(wire.ServerParameters(ctx))

--- a/postgres/server_response.go
+++ b/postgres/server_response.go
@@ -1,0 +1,107 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/lib/pq/oid"
+
+	"github.com/joshrendek/threat.gg-agent/persistence"
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// maxServerLookupLen bounds the attacker-controlled query we forward to the server's
+// response lookup; anything longer skips the lookup and falls back to local handlers.
+const maxServerLookupLen = 4096
+
+// getCommandResponse is an injectable seam over the gRPC call so the server-matched and
+// miss/error paths are unit-testable without a live server.
+var getCommandResponse = persistence.GetCommandResponse
+
+// resultTextColumn is the single ("result" text) column used to frame an admin-authored
+// row-returning postgres response.
+var resultTextColumn = wire.Columns{
+	// Width -1 is postgres' "variable length" type size for text, so the row value is not
+	// truncated regardless of the authored response length.
+	{Table: 0, Name: "result", Oid: oid.T_text, Width: -1},
+}
+
+// rowReturningVerbs are the leading SQL keywords whose statements return a result set in
+// postgres; everything else (set/begin/commit/insert/...) reports only a CommandComplete
+// tag. The query is already lowercased by the caller.
+var rowReturningVerbs = []string{"select", "show", "with", "values", "table"}
+
+// isRowReturning reports whether the query should be framed as a data row (true) or as a
+// bare CommandComplete tag (false), based on its leading verb.
+func isRowReturning(query string) bool {
+	fields := strings.Fields(query)
+	if len(fields) == 0 {
+		return false
+	}
+	verb := strings.ToLower(fields[0])
+	for _, v := range rowReturningVerbs {
+		if verb == v {
+			return true
+		}
+	}
+	return false
+}
+
+// commandTag returns the CommandComplete tag for a non-row statement. The stored response
+// is what psql displays for such a statement, so a non-empty authored response is used
+// verbatim; an empty response derives the tag from the statement's verb (e.g. "SET").
+func commandTag(query, response string) string {
+	if t := strings.TrimSpace(response); t != "" {
+		return t
+	}
+	fields := strings.Fields(query)
+	if len(fields) == 0 {
+		return "OK"
+	}
+	return strings.ToUpper(fields[0])
+}
+
+// writeFramedResponse renders an admin-authored postgres response onto the wire writer.
+// The postgres wire protocol is binary/message-framed, so admins author plain text and the
+// honeypot handles the framing: a row-returning query emits the stored text as a single
+// ("result" text) row and completes as SELECT 1; a tag statement emits only a
+// CommandComplete carrying the derived/authored tag.
+func writeFramedResponse(rowReturning bool, response, query string, writer wire.DataWriter) error {
+	if rowReturning {
+		if err := writer.Row([]any{response}); err != nil {
+			return err
+		}
+		return writer.Complete("SELECT 1")
+	}
+	return writer.Complete(commandTag(query, response))
+}
+
+// serverStatement builds the prepared statement that renders an admin-authored response,
+// selecting the ("result" text) column set only for row-returning queries.
+func serverStatement(query, response string) wire.PreparedStatements {
+	rowReturning := isRowReturning(query)
+	handle := func(ctx context.Context, writer wire.DataWriter, _ []wire.Parameter) error {
+		return writeFramedResponse(rowReturning, response, query, writer)
+	}
+	if rowReturning {
+		return wire.Prepared(wire.NewStatement(handle, wire.WithColumns(resultTextColumn)))
+	}
+	return wire.Prepared(wire.NewStatement(handle))
+}
+
+// lookupServerStatement consults the admin-editable command_responses (scoped to
+// command_type="postgres") for the given (already-lowercased) query. It returns
+// (statement, true) on a Matched row and (nil, false) on a miss, an error, or an oversized
+// query, so the caller falls back to the hardcoded responses map and behavior never
+// regresses when the server is unreachable.
+func lookupServerStatement(query string) (wire.PreparedStatements, bool) {
+	if len(query) > maxServerLookupLen {
+		return nil, false
+	}
+	resp, err := getCommandResponse(&proto.CommandRequest{Command: query, CommandType: "postgres"})
+	if err != nil || resp == nil || !resp.Matched {
+		return nil, false
+	}
+	return serverStatement(query, resp.Response), true
+}

--- a/postgres/server_response_test.go
+++ b/postgres/server_response_test.go
@@ -1,0 +1,151 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	wire "github.com/jeroenrinzema/psql-wire"
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// fakeWriter is a test double for wire.DataWriter that records the framing calls the
+// honeypot makes, so we can assert postgres wire framing without a live pg connection.
+type fakeWriter struct {
+	rows      [][]any
+	completed string
+	emptied   bool
+}
+
+func (f *fakeWriter) Row(v []any) error          { f.rows = append(f.rows, v); return nil }
+func (f *fakeWriter) Written() uint64            { return uint64(len(f.rows)) }
+func (f *fakeWriter) Empty() error               { f.emptied = true; return nil }
+func (f *fakeWriter) Complete(desc string) error { f.completed = desc; return nil }
+
+// TestIsRowReturning: row-returning verbs (select/show/with/values/table) frame as a data
+// row; everything else (set/begin/commit/insert/...) frames as a CommandComplete tag.
+func TestIsRowReturning(t *testing.T) {
+	rowReturning := []string{
+		"select version()",
+		"  select datname from pg_database;",
+		"SHOW server_version",
+		"with x as (select 1) select * from x",
+		"values (1)",
+		"table pg_database",
+	}
+	for _, q := range rowReturning {
+		if !isRowReturning(q) {
+			t.Errorf("isRowReturning(%q) = false, want true", q)
+		}
+	}
+	commandTagOnly := []string{
+		"set datestyle to 'iso'",
+		"begin",
+		"commit",
+		"rollback",
+		"insert into t values (1)",
+		"reset all",
+	}
+	for _, q := range commandTagOnly {
+		if isRowReturning(q) {
+			t.Errorf("isRowReturning(%q) = true, want false", q)
+		}
+	}
+}
+
+// TestCommandTag: the stored response is what psql displays for a tag statement, so a
+// non-empty response is used verbatim; an empty response derives the tag from the verb.
+func TestCommandTag(t *testing.T) {
+	if got := commandTag("begin", "BEGIN"); got != "BEGIN" {
+		t.Errorf("commandTag with authored response = %q, want BEGIN", got)
+	}
+	if got := commandTag("set datestyle to 'iso'", ""); got != "SET" {
+		t.Errorf("commandTag empty response = %q, want SET (derived from verb)", got)
+	}
+}
+
+// TestWriteFramedResponse: row-returning queries emit one ("result" text) row then
+// SELECT 1; tag statements emit only a CommandComplete with no rows.
+func TestWriteFramedResponse(t *testing.T) {
+	// Row-returning: single row carrying the stored text, completed as SELECT 1.
+	fw := &fakeWriter{}
+	if err := writeFramedResponse(true, "PostgreSQL 14.11", "select version()", fw); err != nil {
+		t.Fatalf("writeFramedResponse row: %v", err)
+	}
+	if len(fw.rows) != 1 || len(fw.rows[0]) != 1 || fw.rows[0][0] != "PostgreSQL 14.11" {
+		t.Fatalf("row framing wrote %v, want one single-column row with the stored text", fw.rows)
+	}
+	if fw.completed != "SELECT 1" {
+		t.Fatalf("row framing completed %q, want SELECT 1", fw.completed)
+	}
+
+	// Tag statement: no rows, CommandComplete carries the tag.
+	fw = &fakeWriter{}
+	if err := writeFramedResponse(false, "", "begin", fw); err != nil {
+		t.Fatalf("writeFramedResponse tag: %v", err)
+	}
+	if len(fw.rows) != 0 {
+		t.Fatalf("tag framing wrote rows %v, want none", fw.rows)
+	}
+	if fw.completed != "BEGIN" {
+		t.Fatalf("tag framing completed %q, want BEGIN", fw.completed)
+	}
+}
+
+// TestLookupServerStatement exercises the seam: a Matched row yields a statement (ok=true);
+// a miss, an error, and an oversized query all yield ok=false so the caller falls back to
+// the hardcoded responses map. The lookup is scoped to command_type="postgres".
+func TestLookupServerStatement(t *testing.T) {
+	orig := getCommandResponse
+	defer func() { getCommandResponse = orig }()
+
+	// Matched → handled.
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "postgres" {
+			t.Fatalf("command_type = %q, want postgres", in.CommandType)
+		}
+		if in.Command != "select version()" {
+			t.Fatalf("command = %q, want the query", in.Command)
+		}
+		return &proto.CommandResponse{Response: "PostgreSQL 14.11", Matched: true}, nil
+	}
+	if stmt, ok := lookupServerStatement("select version()"); !ok || stmt == nil {
+		t.Fatalf("matched: ok=%v stmt=%v; want true, non-nil", ok, stmt)
+	}
+
+	// Not matched → fall back.
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Response: "x", Matched: false}, nil
+	}
+	if _, ok := lookupServerStatement("select 1"); ok {
+		t.Fatal("unmatched: ok=true, want false")
+	}
+
+	// Error → fall back.
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		return nil, errors.New("boom")
+	}
+	if _, ok := lookupServerStatement("select 1"); ok {
+		t.Fatal("error: ok=true, want false")
+	}
+
+	// Oversized → not forwarded.
+	called := false
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		called = true
+		return &proto.CommandResponse{Response: "x", Matched: true}, nil
+	}
+	if _, ok := lookupServerStatement(strings.Repeat("a", maxServerLookupLen+1)); ok {
+		t.Fatal("oversized: ok=true, want false")
+	}
+	if called {
+		t.Fatal("oversized query must not be forwarded to the server lookup")
+	}
+}
+
+// compile-time assurance the fake satisfies the wire interface used by the framing code.
+var _ wire.DataWriter = (*fakeWriter)(nil)
+
+// silence unused import in case context is only referenced transitively.
+var _ = context.Background

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"bufio"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -15,10 +16,38 @@ import (
 )
 
 const (
-	maxCommands    = 500
-	totalTimeout   = 300 * time.Second
-	idleTimeout    = 30 * time.Second
+	maxCommands  = 500
+	totalTimeout = 300 * time.Second
+	idleTimeout  = 30 * time.Second
+
+	// maxServerLookupLen bounds the attacker-controlled command we forward to the server's
+	// response lookup; anything longer skips the lookup and falls back to local handlers.
+	maxServerLookupLen = 4096
 )
+
+// getCommandResponse is an injectable seam over the gRPC call so the server-matched and
+// miss/error paths are unit-testable without a live server.
+var getCommandResponse = persistence.GetCommandResponse
+
+// serverResponse writes an admin-authored redis response VERBATIM to w when the server has
+// a Matched row for (command_type="redis", payload=fullCmd). RESP is line-oriented text, so
+// the stored response is exact RESP frames authored by the admin (e.g. "+PONG\r\n",
+// "$4\r\nPONG\r\n"). Returns handled=true when it served the command (caller skips the
+// hardcoded switch); on miss, error, or oversized input it returns handled=false and the
+// caller falls back to the local handlers, so behavior never regresses if the server is
+// unreachable or has no row. Matched (not an empty Response) distinguishes an intentionally
+// silent authored row from a miss.
+func serverResponse(fullCmd string, w io.Writer) (handled bool, err error) {
+	if len(fullCmd) > maxServerLookupLen {
+		return false, nil
+	}
+	resp, lookupErr := getCommandResponse(&proto.CommandRequest{Command: fullCmd, CommandType: "redis"})
+	if lookupErr != nil || resp == nil || !resp.Matched {
+		return false, nil
+	}
+	_, werr := io.WriteString(w, resp.Response)
+	return true, werr
+}
 
 var _ honeypots.Honeypot = &honeypot{}
 
@@ -104,6 +133,17 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 			Str("session", sess.guid).
 			Str("command", cmd).
 			Msg("command received")
+
+		// Server-authored response override (admin-editable command_responses, scoped to
+		// command_type="redis"). On a Matched row we write it verbatim and skip the
+		// hardcoded switch; on miss/error we fall through so behavior never regresses if
+		// the server is unreachable.
+		if handled, respErr := serverResponse(fullCmd, conn); handled {
+			if respErr != nil {
+				break
+			}
+			continue
+		}
 
 		var cmdErr error
 		switch cmd {

--- a/redis/server_response_test.go
+++ b/redis/server_response_test.go
@@ -1,0 +1,71 @@
+package redis
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// TestServerResponse_OverrideAndFallback exercises the redis server-authored override via
+// the injectable getCommandResponse seam. RESP is line-oriented text, so a Matched row is
+// written to the connection VERBATIM (the admin authors exact RESP frames). A miss, an
+// error, and an oversized command all return handled=false so the caller falls back to the
+// hardcoded switch (the no-regression guarantee).
+func TestServerResponse_OverrideAndFallback(t *testing.T) {
+	orig := getCommandResponse
+	defer func() { getCommandResponse = orig }()
+
+	// (a) Matched=true → verbatim RESP bytes written, handled=true, scoped to command_type=redis.
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "redis" {
+			t.Fatalf("command_type = %q, want redis", in.CommandType)
+		}
+		if in.Command != "MODULE LOAD /tmp/exp.so" {
+			t.Fatalf("command = %q, want the full joined command", in.Command)
+		}
+		return &proto.CommandResponse{Response: "+OK\r\n", Matched: true}, nil
+	}
+	var buf bytes.Buffer
+	handled, err := serverResponse("MODULE LOAD /tmp/exp.so", &buf)
+	if !handled || err != nil {
+		t.Fatalf("matched: handled=%v err=%v; want true, nil", handled, err)
+	}
+	if buf.String() != "+OK\r\n" {
+		t.Fatalf("matched: wrote %q, want %q (verbatim)", buf.String(), "+OK\r\n")
+	}
+
+	// (b) Matched=false → handled=false, nothing written (caller falls back to switch).
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Response: "IGNORED", Matched: false}, nil
+	}
+	buf.Reset()
+	if handled, _ := serverResponse("PING", &buf); handled || buf.Len() != 0 {
+		t.Fatalf("unmatched: handled=%v wrote %q; want false, empty", handled, buf.String())
+	}
+
+	// (c) server error → handled=false (fall back).
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		return nil, errors.New("boom")
+	}
+	buf.Reset()
+	if handled, _ := serverResponse("PING", &buf); handled || buf.Len() != 0 {
+		t.Fatalf("error: handled=%v wrote %q; want false, empty", handled, buf.String())
+	}
+
+	// (d) oversized input must NOT be forwarded to the server lookup.
+	called := false
+	getCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		called = true
+		return &proto.CommandResponse{Response: "X", Matched: true}, nil
+	}
+	buf.Reset()
+	if handled, _ := serverResponse(strings.Repeat("a", maxServerLookupLen+1), &buf); handled {
+		t.Fatal("oversized: handled must be false")
+	}
+	if called {
+		t.Fatal("oversized input must not be forwarded to the server lookup")
+	}
+}


### PR DESCRIPTION
Phase 3 of honeypot command-responses. Mirrors the merged telnet hook (PR #18) in the **redis** and **postgres** honeypots.

## Pattern (per protocol)
Each honeypot consults the admin-editable `command_responses` (scoped by `command_type`) before its hardcoded handler and branches on `Matched`, so behavior never regresses when the server is unreachable or has no authored row. An injectable `getCommandResponse` seam + `maxServerLookupLen` cap make the matched/miss/error/oversized paths unit-testable without a live server.

## redis — verbatim RESP
RESP is line-oriented text, so a `Matched` row is written to the connection **verbatim** (admins author exact frames, e.g. `+PONG\r\n`, `+OK\r\n`). Hook sits before the command switch in `handleConnection`.

## postgres — framed
The pg wire protocol is binary/message-framed, so the agent **frames** the stored plain text:
- row-returning queries (`select`/`show`/`with`/`values`/`table`) → single (`result` text) row, completed as `SELECT 1`
- `set`/`begin`-style statements → `CommandComplete` tag (authored response verbatim, else derived from the verb)

Admins author plain text; the honeypot handles the framing. **No server change needed** — `GetCommandResponse` already scopes by `(command_type, payload)` for any type.

## Tests
- `redis/server_response_test.go`, `postgres/server_response_test.go` — matched/miss/error/oversized + framing decisions, all via the seam (no live server).
- `go build ./... && go vet ./... && go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)