### PR TITLE
feat(honeypots): sweep admin-editable command responses across 9 more protocols

### DIFF
--- a/cmdresp/cmdresp.go
+++ b/cmdresp/cmdresp.go
@@ -1,0 +1,88 @@
+// Package cmdresp is the shared client side of the admin-editable command_responses
+// override. Every honeypot consults it (scoped by command_type) before its hardcoded
+// handler and branches on Matched, so behavior never regresses when the server is
+// unreachable or has no authored row. It centralizes the gRPC seam, the input cap, the
+// HTTP body/middleware framing, and the SQL result framing so each honeypot is a thin
+// call site. (ssh/telnet/redis/postgres predate this package and keep their own seams.)
+package cmdresp
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/joshrendek/threat.gg-agent/persistence"
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// MaxServerLookupLen bounds the attacker-controlled command forwarded to the server's
+// response lookup; anything longer skips the lookup and falls back to local handlers.
+const MaxServerLookupLen = 4096
+
+// GetCommandResponse is an injectable seam over the gRPC call so the matched/miss/error
+// paths are unit-testable without a live server.
+var GetCommandResponse = persistence.GetCommandResponse
+
+// Lookup returns the admin-authored response for (commandType, command) when a Matched row
+// exists, and ("", false) on a miss, an error, or an oversized command — so the caller
+// falls back to its hardcoded handler. Matched (not a non-empty Response) is the gate, so
+// an intentionally-silent authored row is honored rather than treated as a miss.
+func Lookup(commandType, command string) (string, bool) {
+	if len(command) > MaxServerLookupLen {
+		return "", false
+	}
+	resp, err := GetCommandResponse(&proto.CommandRequest{Command: command, CommandType: commandType})
+	if err != nil || resp == nil || !resp.Matched {
+		return "", false
+	}
+	return resp.Response, true
+}
+
+// HTTPOverride writes an admin-authored response as the HTTP body when a row is authored
+// for (commandType, "METHOD /path"), returning true when it handled the request. The
+// caller's already-set Content-Type/headers are preserved; on a miss it writes nothing and
+// returns false so the caller renders its default response.
+func HTTPOverride(w http.ResponseWriter, r *http.Request, commandType string) bool {
+	body, ok := Lookup(commandType, r.Method+" "+r.URL.Path)
+	if !ok {
+		return false
+	}
+	io.WriteString(w, body) //nolint:errcheck
+	return true
+}
+
+// MuxMiddleware returns net/http middleware (compatible with gorilla/mux Router.Use) that
+// applies HTTPOverride before the wrapped handler, intercepting a Matched request and
+// otherwise falling through unchanged.
+func MuxMiddleware(commandType string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if HTTPOverride(w, r, commandType) {
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// rowReturningVerbs are the leading SQL keywords whose statements return a result set;
+// everything else (set/use/insert/...) reports only an OK/completion packet. Shared by the
+// binary tabular honeypots (mysql) to decide how to frame stored plain text into a wire
+// result.
+var rowReturningVerbs = []string{"select", "show", "with", "values", "table"}
+
+// IsRowReturning reports whether a query should be framed as a data row (true) or as a bare
+// OK/completion packet (false), based on its leading verb (case-insensitive).
+func IsRowReturning(query string) bool {
+	fields := strings.Fields(query)
+	if len(fields) == 0 {
+		return false
+	}
+	verb := strings.ToLower(fields[0])
+	for _, v := range rowReturningVerbs {
+		if verb == v {
+			return true
+		}
+	}
+	return false
+}

--- a/cmdresp/cmdresp_test.go
+++ b/cmdresp/cmdresp_test.go
@@ -1,0 +1,146 @@
+package cmdresp
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// stub swaps the gRPC seam for a test double and restores it on cleanup.
+func stub(t *testing.T, fn func(*proto.CommandRequest) (*proto.CommandResponse, error)) {
+	t.Helper()
+	orig := GetCommandResponse
+	GetCommandResponse = fn
+	t.Cleanup(func() { GetCommandResponse = orig })
+}
+
+// TestLookup covers the shared gate every honeypot relies on: a Matched row returns
+// (response, true); a miss, an error, and an oversized command all return ("", false) so
+// the caller falls back to its hardcoded handler. The request carries the given
+// command_type and command verbatim.
+func TestLookup(t *testing.T) {
+	// Matched.
+	stub(t, func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "ftp" || in.Command != "SYST" {
+			t.Fatalf("forwarded (%q,%q), want (ftp,SYST)", in.CommandType, in.Command)
+		}
+		return &proto.CommandResponse{Response: "215 UNIX Type: L8\r\n", Matched: true}, nil
+	})
+	if got, ok := Lookup("ftp", "SYST"); !ok || got != "215 UNIX Type: L8\r\n" {
+		t.Fatalf("matched: (%q,%v), want the response,true", got, ok)
+	}
+
+	// Miss (Matched=false).
+	stub(t, func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Response: "x", Matched: false}, nil
+	})
+	if got, ok := Lookup("ftp", "SYST"); ok || got != "" {
+		t.Fatalf("miss: (%q,%v), want empty,false", got, ok)
+	}
+
+	// Error.
+	stub(t, func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return nil, errors.New("boom")
+	})
+	if _, ok := Lookup("ftp", "SYST"); ok {
+		t.Fatal("error: ok=true, want false")
+	}
+
+	// Oversized → not forwarded.
+	called := false
+	stub(t, func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		called = true
+		return &proto.CommandResponse{Response: "x", Matched: true}, nil
+	})
+	if _, ok := Lookup("ftp", strings.Repeat("a", MaxServerLookupLen+1)); ok {
+		t.Fatal("oversized: ok=true, want false")
+	}
+	if called {
+		t.Fatal("oversized command must not be forwarded")
+	}
+}
+
+// TestHTTPOverride: a Matched row for "METHOD /path" is written as the HTTP body and
+// returns true; a miss returns false and writes nothing so the caller renders its default.
+func TestHTTPOverride(t *testing.T) {
+	stub(t, func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "elasticsearch" || in.Command != "GET /_cat/indices" {
+			t.Fatalf("forwarded (%q,%q), want (elasticsearch,GET /_cat/indices)", in.CommandType, in.Command)
+		}
+		return &proto.CommandResponse{Response: `{"ok":true}`, Matched: true}, nil
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/_cat/indices", nil)
+	if !HTTPOverride(rec, req, "elasticsearch") {
+		t.Fatal("matched: HTTPOverride returned false, want true")
+	}
+	if rec.Body.String() != `{"ok":true}` {
+		t.Fatalf("matched body = %q, want the response", rec.Body.String())
+	}
+
+	// Miss → false, nothing written.
+	stub(t, func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Matched: false}, nil
+	})
+	rec = httptest.NewRecorder()
+	if HTTPOverride(rec, httptest.NewRequest(http.MethodGet, "/", nil), "elasticsearch") {
+		t.Fatal("miss: HTTPOverride returned true, want false")
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("miss wrote %q, want nothing", rec.Body.String())
+	}
+}
+
+// TestMuxMiddleware: on a Matched row the wrapped handler is NOT called and the override
+// body is written; on a miss the wrapped handler runs normally.
+func TestMuxMiddleware(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.Write([]byte("DEFAULT"))
+	})
+
+	stub(t, func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Response: "OVERRIDE", Matched: true}, nil
+	})
+	rec := httptest.NewRecorder()
+	MuxMiddleware("docker")(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/version", nil))
+	if nextCalled {
+		t.Fatal("matched: wrapped handler was called, want intercepted")
+	}
+	if rec.Body.String() != "OVERRIDE" {
+		t.Fatalf("matched body = %q, want OVERRIDE", rec.Body.String())
+	}
+
+	nextCalled = false
+	stub(t, func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Matched: false}, nil
+	})
+	rec = httptest.NewRecorder()
+	MuxMiddleware("docker")(next).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/version", nil))
+	if !nextCalled {
+		t.Fatal("miss: wrapped handler was not called, want fallthrough")
+	}
+	if rec.Body.String() != "DEFAULT" {
+		t.Fatalf("miss body = %q, want DEFAULT", rec.Body.String())
+	}
+}
+
+// TestIsRowReturning: the SQL framing helper shared by the postgres-style binary honeypots
+// (mysql). Row-returning verbs render as a data row; other statements render as an OK packet.
+func TestIsRowReturning(t *testing.T) {
+	for _, q := range []string{"select 1", "  SHOW databases", "with x as (select 1) select *", "values (1)", "table t"} {
+		if !IsRowReturning(q) {
+			t.Errorf("IsRowReturning(%q)=false, want true", q)
+		}
+	}
+	for _, q := range []string{"set names utf8", "begin", "insert into t values (1)", "use mysql", ""} {
+		if IsRowReturning(q) {
+			t.Errorf("IsRowReturning(%q)=true, want false", q)
+		}
+	}
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 	"github.com/joshrendek/threat.gg-agent/honeypots"
 	"github.com/joshrendek/threat.gg-agent/persistence"
 	"github.com/joshrendek/threat.gg-agent/proto"
@@ -16,10 +17,10 @@ import (
 )
 
 const (
-	defaultPort    = "2375"
-	maxBodySize    = 1 << 20 // 1MB
-	serverVersion  = "24.0.7"
-	apiVersion     = "1.43"
+	defaultPort     = "2375"
+	maxBodySize     = 1 << 20 // 1MB
+	serverVersion   = "24.0.7"
+	apiVersion      = "1.43"
 	fakeContainerID = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
 	fakeExecID      = "e1f2a3b4c5d6e1f2a3b4c5d6e1f2a3b4c5d6e1f2a3b4c5d6e1f2a3b4c5d6e1f2"
 )
@@ -45,6 +46,10 @@ func (h *honeypot) Start() {
 	}
 
 	r := mux.NewRouter()
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="docker"), keyed by "METHOD /path". Intercepts before the routes below;
+	// on a miss/error it falls through unchanged.
+	r.Use(cmdresp.MuxMiddleware("docker"))
 	registerRoutes(r)
 
 	h.logger.Info().Str("port", port).Msg("starting docker api honeypot")

--- a/elasticsearch/es.go
+++ b/elasticsearch/es.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 	"github.com/joshrendek/threat.gg-agent/persistence"
 	"github.com/joshrendek/threat.gg-agent/proto"
 	"github.com/joshrendek/threat.gg-agent/stats"
@@ -72,6 +73,13 @@ func (e *ES) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			logger.Error().Err(err).Msg("error saving http request")
 		}
 	}(httpReq)
+
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="elasticsearch"), keyed by "METHOD /path". On a miss/error we fall
+	// through to the hardcoded version banner below.
+	if cmdresp.HTTPOverride(w, r, "elasticsearch") {
+		return
+	}
 
 	fmt.Fprintf(w, resp)
 }

--- a/etcd/etcd.go
+++ b/etcd/etcd.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 	"github.com/joshrendek/threat.gg-agent/honeypots"
 	"github.com/joshrendek/threat.gg-agent/persistence"
 	"github.com/joshrendek/threat.gg-agent/proto"
@@ -43,6 +44,10 @@ func (h *honeypot) Start() {
 	}
 
 	r := mux.NewRouter()
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="etcd"), keyed by "METHOD /path". Intercepts before the routes below;
+	// on a miss/error it falls through unchanged.
+	r.Use(cmdresp.MuxMiddleware("etcd"))
 	registerRoutes(r)
 
 	h.logger.Info().Str("port", port).Msg("starting etcd honeypot")

--- a/ftp/server.go
+++ b/ftp/server.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 	"github.com/rs/zerolog"
 )
 
@@ -73,6 +74,15 @@ func handleCommand(input string, ch *ConnectionConfig, user *AuthUser, c net.Con
 
 	if err != nil {
 		return SyntaxErr, err
+	}
+
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="ftp"), keyed by the raw command line. FTP replies are numeric-code
+	// prefixed and carry their own trailing CRLF, and sendMsg writes verbatim, so an
+	// authored response is returned as-is. On a miss/error we fall through to the hardcoded
+	// replies below, so behavior never regresses if the server is unreachable.
+	if resp, ok := cmdresp.Lookup("ftp", input); ok {
+		return resp, nil
 	}
 
 	ignoredCommands := []string{

--- a/ftp/server_response_test.go
+++ b/ftp/server_response_test.go
@@ -1,0 +1,46 @@
+package ftp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+)
+
+// fakeConn is a minimal net.Conn whose only usable method is RemoteAddr (all handleCommand
+// needs on the override path). Any other call panics, which is fine — the override returns
+// before touching the connection.
+type fakeConn struct{ net.Conn }
+
+func (fakeConn) RemoteAddr() net.Addr { return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 21} }
+
+// TestHandleCommand_ServerOverride: a Matched ftp row is returned verbatim (admins author
+// the full "NNN ...\r\n" reply, since sendMsg adds no framing); a miss falls back to the
+// hardcoded reply. The lookup is scoped to command_type="ftp" and keyed by the raw line.
+func TestHandleCommand_ServerOverride(t *testing.T) {
+	orig := cmdresp.GetCommandResponse
+	defer func() { cmdresp.GetCommandResponse = orig }()
+
+	// (a) Matched → verbatim override wins over the hardcoded SysType.
+	cmdresp.GetCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "ftp" || in.Command != "SYST" {
+			t.Fatalf("forwarded (%q,%q), want (ftp,SYST)", in.CommandType, in.Command)
+		}
+		return &proto.CommandResponse{Response: "215 UNIX Type: L8 (custom)\r\n", Matched: true}, nil
+	}
+	out, err := handleCommand("SYST", &ConnectionConfig{}, &AuthUser{}, fakeConn{}, zerolog.Nop())
+	if err != nil || out != "215 UNIX Type: L8 (custom)\r\n" {
+		t.Fatalf("matched: (%q,%v), want the override,nil", out, err)
+	}
+
+	// (b) Miss → hardcoded SysType.
+	cmdresp.GetCommandResponse = func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Matched: false}, nil
+	}
+	out, err = handleCommand("SYST", &ConnectionConfig{}, &AuthUser{}, fakeConn{}, zerolog.Nop())
+	if err != nil || out != SysType {
+		t.Fatalf("miss: (%q,%v), want SysType,nil", out, err)
+	}
+}

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 	"github.com/joshrendek/threat.gg-agent/honeypots"
 	"github.com/joshrendek/threat.gg-agent/persistence"
 	pb "github.com/joshrendek/threat.gg-agent/proto"
@@ -78,6 +79,13 @@ func (h *honeypot) handleRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "Jetty(10.0.18)")
 	w.Header().Set("X-Jenkins", "2.426.3")
 	w.Header().Set("X-Jenkins-Session", "ad9f8d49")
+
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="jenkins"), keyed by "METHOD /path". The common Jenkins headers above
+	// are preserved; on a miss/error we fall through to the hardcoded routes below.
+	if cmdresp.HTTPOverride(w, r, "jenkins") {
+		return
+	}
 
 	switch r.URL.Path {
 	case "/script", "/scriptText":

--- a/jenkins/server_response_test.go
+++ b/jenkins/server_response_test.go
@@ -1,0 +1,48 @@
+package jenkins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+	pb "github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+)
+
+// TestHandleRequest_ServerOverride proves the HTTPOverride wiring for a net/http honeypot:
+// a Matched jenkins row (keyed by "METHOD /path") is written as the body while the common
+// Jenkins headers are preserved; a miss falls through to the hardcoded dashboard. Scoped to
+// command_type="jenkins".
+func TestHandleRequest_ServerOverride(t *testing.T) {
+	orig := cmdresp.GetCommandResponse
+	defer func() { cmdresp.GetCommandResponse = orig }()
+	cmdresp.GetCommandResponse = func(in *pb.CommandRequest) (*pb.CommandResponse, error) {
+		if in.CommandType == "jenkins" && in.Command == "GET /secret" {
+			return &pb.CommandResponse{Response: "CUSTOM-BODY", Matched: true}, nil
+		}
+		return &pb.CommandResponse{Matched: false}, nil
+	}
+	h := &honeypot{logger: zerolog.Nop(), save: func(*pb.JenkinsRequest) error { return nil }}
+
+	// (a) Matched → override body, common headers preserved.
+	rec := httptest.NewRecorder()
+	h.handleRequest(rec, httptest.NewRequest(http.MethodGet, "/secret", nil))
+	if rec.Body.String() != "CUSTOM-BODY" {
+		t.Fatalf("matched body = %q, want CUSTOM-BODY", rec.Body.String())
+	}
+	if rec.Header().Get("X-Jenkins") == "" {
+		t.Fatal("matched: expected X-Jenkins header to be preserved on an override")
+	}
+
+	// (b) Miss → hardcoded dashboard HTML.
+	rec = httptest.NewRecorder()
+	h.handleRequest(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Body.String() == "CUSTOM-BODY" {
+		t.Fatal("miss: got the override body, want the hardcoded dashboard")
+	}
+	if !strings.Contains(rec.Header().Get("Content-Type"), "text/html") {
+		t.Fatalf("miss Content-Type = %q, want text/html", rec.Header().Get("Content-Type"))
+	}
+}

--- a/kubernetes/k8s.go
+++ b/kubernetes/k8s.go
@@ -10,6 +10,7 @@ import (
   "fmt"
   "github.com/gorilla/mux"
   "github.com/joshrendek/hnypots-agent/honeypots"
+  "github.com/joshrendek/threat.gg-agent/cmdresp"
   "github.com/rs/zerolog"
   "math/big"
   "net/http"
@@ -36,6 +37,10 @@ func (h *honeypot) Start() {
 	fmt.Println("----------- START K8s")
 	router := mux.NewRouter()
 	router.Use(h.LoggingMiddleware)
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="kubernetes"), keyed by "METHOD /path". Intercepts before the routes
+	// below (including the catch-all); on a miss/error it falls through unchanged.
+	router.Use(cmdresp.MuxMiddleware("kubernetes"))
 
 	// Handle /version for cluster-info
 	router.HandleFunc("/version", h.versionHandler).Methods("GET")

--- a/ldap/ldap.go
+++ b/ldap/ldap.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"sync"
 
+	ldapserver "github.com/joshrendek/threat.gg-agent/internal/ldapserver"
 	ldapmsg "github.com/lor00x/goldap/message"
 	"github.com/rs/zerolog"
 	uuid "github.com/satori/go.uuid"
-	ldapserver "github.com/joshrendek/threat.gg-agent/internal/ldapserver"
 
 	"github.com/joshrendek/threat.gg-agent/honeypots"
 	"github.com/joshrendek/threat.gg-agent/persistence"
@@ -221,8 +221,17 @@ func handleSearch(w ldapserver.ResponseWriter, m *ldapserver.Message) {
 		return
 	}
 
-	// Search fake directory
-	entries := searchEntries(baseDN, filter, scope)
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="ldap"), keyed by "baseDN filter". The admin authors LDIF; parseLDIF
+	// turns it into entries and the ldap library frames the BER wire response. On a
+	// miss/error we fall through to the hardcoded fake directory below, so behavior never
+	// regresses if the server is unreachable. (RootDSE and JNDI handling above are left
+	// intact.)
+	entries, overridden := ldapSearchOverride(baseDN, filter)
+	if !overridden {
+		// Search fake directory
+		entries = searchEntries(baseDN, filter, scope)
+	}
 	for _, entry := range entries {
 		e := ldapserver.NewSearchResultEntry(entry.dn)
 		for k, vals := range entry.attributes {

--- a/ldap/server_response.go
+++ b/ldap/server_response.go
@@ -1,0 +1,58 @@
+package ldap
+
+import (
+	"strings"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+)
+
+// parseLDIF parses an admin-authored LDIF response into directory entries the honeypot can
+// replay. Entries are separated by blank lines; a "dn:" line starts an entry and each
+// subsequent "attr: value" line adds an attribute (repeatable for multi-valued attributes).
+// Comment lines ("#..."), malformed lines, and anything before the first "dn:" are ignored.
+// Returns nil when no entries are found. This lets admins author plain LDIF while the
+// honeypot handles the BER wire framing (via the ldap library).
+func parseLDIF(ldif string) []directoryEntry {
+	var entries []directoryEntry
+	var cur *directoryEntry
+
+	for _, raw := range strings.Split(ldif, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if strings.TrimSpace(line) == "" {
+			cur = nil // blank line ends the current entry
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		idx := strings.IndexByte(line, ':')
+		if idx < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		val := strings.TrimSpace(line[idx+1:])
+		if strings.EqualFold(key, "dn") {
+			entries = append(entries, directoryEntry{dn: val, attributes: map[string][]string{}})
+			cur = &entries[len(entries)-1]
+			continue
+		}
+		if cur == nil { // an attribute line before any dn is ignored
+			continue
+		}
+		cur.attributes[key] = append(cur.attributes[key], val)
+	}
+
+	return entries
+}
+
+// ldapSearchOverride consults the admin-editable command_responses (scoped to
+// command_type="ldap") for a search, keyed by "baseDN filter". It returns the parsed
+// entries and ok=true on a Matched row, or (nil, false) on a miss/error/oversized key so
+// the caller falls back to the hardcoded fake directory.
+func ldapSearchOverride(baseDN, filter string) ([]directoryEntry, bool) {
+	resp, ok := cmdresp.Lookup("ldap", baseDN+" "+filter)
+	if !ok {
+		return nil, false
+	}
+	return parseLDIF(resp), true
+}

--- a/ldap/server_response_test.go
+++ b/ldap/server_response_test.go
@@ -1,0 +1,71 @@
+package ldap
+
+import (
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// TestParseLDIF: an admin authors LDAP search results as LDIF text; parseLDIF turns it into
+// directory entries the honeypot replays. Entries are blank-line separated; "dn:" starts an
+// entry; "attr: value" adds an attribute (repeatable for multi-valued). Junk before the
+// first dn and malformed lines are ignored; empty input yields no entries.
+func TestParseLDIF(t *testing.T) {
+	ldif := `# a comment before any dn is ignored
+dn: cn=admin,dc=corp,dc=com
+objectClass: person
+cn: admin
+mail: admin@corp.com
+mail: admin@alt.corp.com
+
+dn: cn=svc,dc=corp,dc=com
+cn: svc
+`
+	entries := parseLDIF(ldif)
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	if entries[0].dn != "cn=admin,dc=corp,dc=com" {
+		t.Fatalf("entry0 dn = %q", entries[0].dn)
+	}
+	if got := entries[0].attributes["mail"]; len(got) != 2 {
+		t.Fatalf("entry0 mail = %v, want 2 values", got)
+	}
+	if entries[0].attributes["cn"][0] != "admin" {
+		t.Fatalf("entry0 cn = %v", entries[0].attributes["cn"])
+	}
+	if entries[1].dn != "cn=svc,dc=corp,dc=com" {
+		t.Fatalf("entry1 dn = %q", entries[1].dn)
+	}
+
+	if parseLDIF("   \n\n") != nil {
+		t.Fatal("blank input should yield nil entries")
+	}
+}
+
+// TestLDAPSearchOverride: the seam is scoped to command_type="ldap" and keyed by
+// "baseDN filter"; a Matched row yields the parsed entries (ok=true), a miss yields
+// ok=false so the caller falls back to the hardcoded fake directory.
+func TestLDAPSearchOverride(t *testing.T) {
+	orig := cmdresp.GetCommandResponse
+	defer func() { cmdresp.GetCommandResponse = orig }()
+
+	cmdresp.GetCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "ldap" || in.Command != "dc=corp,dc=com (objectClass=*)" {
+			t.Fatalf("forwarded (%q,%q), want (ldap, baseDN+filter)", in.CommandType, in.Command)
+		}
+		return &proto.CommandResponse{Response: "dn: cn=x,dc=corp,dc=com\ncn: x\n", Matched: true}, nil
+	}
+	entries, ok := ldapSearchOverride("dc=corp,dc=com", "(objectClass=*)")
+	if !ok || len(entries) != 1 || entries[0].dn != "cn=x,dc=corp,dc=com" {
+		t.Fatalf("matched: ok=%v entries=%v, want one parsed entry", ok, entries)
+	}
+
+	cmdresp.GetCommandResponse = func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Matched: false}, nil
+	}
+	if _, ok := ldapSearchOverride("dc=corp,dc=com", "(objectClass=*)"); ok {
+		t.Fatal("miss: ok=true, want false")
+	}
+}

--- a/mysql/commands.go
+++ b/mysql/commands.go
@@ -3,14 +3,16 @@ package mysql
 import (
 	"io"
 	"strings"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 )
 
 // MySQL COM_* command bytes
 const (
-	comQuit     byte = 0x01
-	comInitDB   byte = 0x02
-	comQuery    byte = 0x03
-	comPing     byte = 0x0E
+	comQuit       byte = 0x01
+	comInitDB     byte = 0x02
+	comQuery      byte = 0x03
+	comPing       byte = 0x0E
 	comStatistics byte = 0x09
 )
 
@@ -101,6 +103,16 @@ func init() {
 func handleComQuery(w io.Writer, seqID uint8, query string) (uint8, error) {
 	normalized := strings.ToLower(strings.TrimSpace(query))
 
+	// Server-authored response override (admin-editable command_responses, scoped to
+	// command_type="mysql"), keyed by the normalized query. mysql is binary/packet-framed,
+	// so the stored plain text is FRAMED (like postgres): a row-returning query renders as a
+	// single ("result") column/row result set; a non-row statement renders an OK packet. On
+	// a miss/error we fall through to the hardcoded handling below, so behavior never
+	// regresses if the server is unreachable.
+	if resp, ok := cmdresp.Lookup("mysql", normalized); ok {
+		return writeServerResponse(w, seqID, normalized, resp)
+	}
+
 	// Check for exact match in known queries
 	if resp, ok := queryResponses[normalized]; ok {
 		return writeResultSet(w, seqID, resp.columns, resp.rows)
@@ -145,6 +157,21 @@ func handleComQuery(w io.Writer, seqID uint8, query string) (uint8, error) {
 		err := writeOKPacket(w, seqID, 0, 0)
 		return seqID + 1, err
 	}
+}
+
+// writeServerResponse frames an admin-authored mysql response into the binary wire result.
+// A row-returning query renders the stored text as a single ("result") column/row result
+// set; a non-row statement renders an OK packet (mysql OK packets carry no display text, so
+// the stored text is unused there — its value is for row-returning queries).
+func writeServerResponse(w io.Writer, seqID uint8, query, response string) (uint8, error) {
+	if cmdresp.IsRowReturning(query) {
+		col := columnDef{Name: "result", ColType: 0xFD, MaxLen: 65535} // MYSQL_TYPE_VAR_STRING
+		return writeResultSet(w, seqID, []columnDef{col}, [][]string{{response}})
+	}
+	if err := writeOKPacket(w, seqID, 0, 0); err != nil {
+		return seqID, err
+	}
+	return seqID + 1, nil
 }
 
 // handleComPing responds to COM_PING.

--- a/mysql/server_response_test.go
+++ b/mysql/server_response_test.go
@@ -1,0 +1,61 @@
+package mysql
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// TestHandleComQuery_ServerOverride: mysql is binary/packet-framed like postgres, so a
+// Matched mysql row is FRAMED — a row-returning query renders the stored text as a single
+// ("result") column/row result set; a non-row statement renders an OK packet. A miss falls
+// back to the hardcoded queryResponses/prefix handling. Scoped to command_type="mysql",
+// keyed by the normalized (lowercased, trimmed) query.
+func TestHandleComQuery_ServerOverride(t *testing.T) {
+	orig := cmdresp.GetCommandResponse
+	defer func() { cmdresp.GetCommandResponse = orig }()
+
+	// (a) Matched row-returning → the stored text is packed into the result-set row bytes.
+	cmdresp.GetCommandResponse = func(in *proto.CommandRequest) (*proto.CommandResponse, error) {
+		if in.CommandType != "mysql" || in.Command != "select @@version" {
+			t.Fatalf("forwarded (%q,%q), want (mysql,select @@version)", in.CommandType, in.Command)
+		}
+		return &proto.CommandResponse{Response: "8.0.35-CUSTOM", Matched: true}, nil
+	}
+	var buf bytes.Buffer
+	if _, err := handleComQuery(&buf, 1, "SELECT @@version"); err != nil {
+		t.Fatalf("matched row-returning: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("8.0.35-CUSTOM")) {
+		t.Fatalf("matched row-returning: result set missing the stored text; got % x", buf.Bytes())
+	}
+
+	// (b) Matched non-row → OK packet (0x00 marker), stored text NOT rendered as a row.
+	cmdresp.GetCommandResponse = func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Response: "IGNORED-FOR-OK", Matched: true}, nil
+	}
+	buf.Reset()
+	if _, err := handleComQuery(&buf, 1, "SET names utf8"); err != nil {
+		t.Fatalf("matched non-row: %v", err)
+	}
+	if bytes.Contains(buf.Bytes(), []byte("IGNORED-FOR-OK")) {
+		t.Fatalf("matched non-row: OK packet must not carry the stored text; got % x", buf.Bytes())
+	}
+	if len(buf.Bytes()) < 5 || buf.Bytes()[4] != 0x00 {
+		t.Fatalf("matched non-row: expected an OK packet (0x00 marker); got % x", buf.Bytes())
+	}
+
+	// (c) Miss → hardcoded path (unknown SELECT returns an empty result set, no panic).
+	cmdresp.GetCommandResponse = func(*proto.CommandRequest) (*proto.CommandResponse, error) {
+		return &proto.CommandResponse{Matched: false}, nil
+	}
+	buf.Reset()
+	if _, err := handleComQuery(&buf, 1, "SELECT something_unknown"); err != nil {
+		t.Fatalf("miss: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("miss: expected the hardcoded handler to write a response")
+	}
+}

--- a/smtp/server_response_test.go
+++ b/smtp/server_response_test.go
@@ -1,0 +1,51 @@
+package smtp
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+	pb "github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// TestHandleConnection_ServerOverride drives the real command loop over a net.Pipe: a
+// Matched smtp row (keyed by the CRLF-trimmed command line) is written verbatim to the
+// client; an unmatched command falls back to the hardcoded reply. This exercises the hook
+// placement + verbatim framing end-to-end.
+func TestHandleConnection_ServerOverride(t *testing.T) {
+	orig := cmdresp.GetCommandResponse
+	defer func() { cmdresp.GetCommandResponse = orig }()
+	cmdresp.GetCommandResponse = func(in *pb.CommandRequest) (*pb.CommandResponse, error) {
+		if in.CommandType == "smtp" && in.Command == "VRFY root" {
+			return &pb.CommandResponse{Response: "250 root <root@corp.com>\r\n", Matched: true}, nil
+		}
+		return &pb.CommandResponse{Matched: false}, nil
+	}
+
+	client, server := net.Pipe()
+	defer client.Close()
+	go handleConnection(server)
+
+	br := bufio.NewReader(client)
+	if _, err := br.ReadString('\n'); err != nil { // consume the 220 banner
+		t.Fatalf("reading banner: %v", err)
+	}
+
+	// (a) Matched → verbatim override.
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+	fmt.Fprint(client, "VRFY root\r\n")
+	line, err := br.ReadString('\n')
+	if err != nil || line != "250 root <root@corp.com>\r\n" {
+		t.Fatalf("matched: (%q,%v), want the override reply", line, err)
+	}
+
+	// (b) Miss → hardcoded VRFY reply.
+	fmt.Fprint(client, "VRFY nobody\r\n")
+	line, err = br.ReadString('\n')
+	if err != nil || line != "252 Cannot VRFY user\r\n" {
+		t.Fatalf("miss: (%q,%v), want the hardcoded 252 reply", line, err)
+	}
+}

--- a/smtp/smtp.go
+++ b/smtp/smtp.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
 	"github.com/rs/zerolog/log"
+	uuid "github.com/satori/go.uuid"
 
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
 	"github.com/joshrendek/threat.gg-agent/persistence"
 	pb "github.com/joshrendek/threat.gg-agent/proto"
 )
@@ -166,6 +167,18 @@ func handleConnection(conn net.Conn) {
 		sess.cmdCount++
 
 		cmd, args := parseCommand(line)
+
+		// Server-authored response override (admin-editable command_responses, scoped to
+		// command_type="smtp"), keyed by the CRLF-trimmed command line. Written verbatim
+		// (admins author the full "NNN ...\r\n" reply). On a miss/error we fall through to
+		// the hardcoded switch, so behavior never regresses if the server is unreachable.
+		// Note: a verbatim override replies but does not advance the session FSM, so it is
+		// best used for stateless verbs (VRFY/EXPN/NOOP/HELP/unknown), not MAIL/RCPT/DATA.
+		if resp, ok := cmdresp.Lookup("smtp", strings.TrimRight(line, "\r\n")); ok {
+			writer.WriteString(resp) //nolint:errcheck
+			writer.Flush()
+			continue
+		}
 
 		switch cmd {
 		case "EHLO":


### PR DESCRIPTION
Extends the honeypot `command_responses` override beyond ssh/telnet/redis/postgres to **every remaining honeypot where a `(command_type, payload) -> response text` model fits**. Follows the merged telnet pattern (PR #18) and the redis/postgres PR (#19): each honeypot consults the admin-editable rows before its hardcoded handler and branches on `Matched`, so behavior never regresses when the server is unreachable or has no row.

## Shared `cmdresp` package
New package centralizes the gRPC seam, input cap, and framing so each honeypot is a thin, reviewed call site:
- `Lookup(commandType, command) (response, ok)` — the `Matched` gate + `MaxServerLookupLen` cap; injectable `GetCommandResponse` seam for tests.
- `HTTPOverride` / `MuxMiddleware` — write the stored response as the HTTP body, keyed by `"METHOD /path"` (net/http and gorilla/mux honeypots).
- `IsRowReturning` — SQL verb classification for binary tabular honeypots.

## Protocols added (9) + framing
| Honeypot | command_type | framing |
|---|---|---|
| ftp | `ftp` | verbatim text (admin authors full `NNN ...\r\n`) |
| smtp | `smtp` | verbatim text (stateless verbs; FSM caveat noted in code) |
| elasticsearch | `elasticsearch` | HTTP body, `METHOD /path` |
| jenkins | `jenkins` | HTTP body, `METHOD /path` (common headers preserved) |
| docker | `docker` | HTTP body via mux middleware |
| etcd | `etcd` | HTTP body via mux middleware (v2 HTTP API) |
| kubernetes | `kubernetes` | HTTP body via mux middleware (before catch-all) |
| mysql | `mysql` | binary-framed like postgres: row-returning -> single (`result`) row; else OK packet |
| ldap | `ldap` | admin authors **LDIF**; `parseLDIF` -> search entries the library BER-encodes; keyed by `"baseDN filter"` (RootDSE/JNDI left intact) |

## Deliberately NOT covered
A 4-agent feasibility sweep found these do not fit the text model, with specific blockers:
- **mqtt** — pub/sub; PUBLISH gets no reply, SUBSCRIBE answers with an out-of-band PUBLISH. No command->response surface.
- **kafka** — responses are versioned per-`(ApiKey, ApiVersion)` binary schemas with CRC32 MessageSets + session state. A text payload can key the request but not author the response.
- **smb / rdp / vnc** — stateful binary credential-harvest handshakes (NTLM/CredSSP/RFB); the only authorable lever is a 1-byte enum or a banner string, not a command->response.
- **webserver** — not registered in `main.go` (dead listener).
- **openclaw** — would need new request-key extraction + JSON envelope/id-echo; deferred.

## Tests
`cmdresp` (Lookup/HTTPOverride/MuxMiddleware/IsRowReturning), ftp (`handleCommand`), smtp (net.Pipe end-to-end), jenkins (httptest, header preservation), mysql (binary result-set framing), ldap (LDIF parse + override seam). The mux HTTP honeypots rely on the tested `cmdresp.MuxMiddleware` + build (their routers are constructed inline in `Start()`). `go build ./... && go vet ./... && go test ./...` all pass.

Server whitelist (`validCommandTypes`) + frontend selector (`COMMAND_TYPES`) are updated separately in the server repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)