### PR TITLE
fix(postgres): advertise server_version in the startup handshake

### DIFF
--- a/postgres/pg.go
+++ b/postgres/pg.go
@@ -65,6 +65,10 @@ func (h *honeypot) Start() {
 	})
 	server, _ := wire.NewServer(handler)
 	server.Auth = auth
+	// Advertise a server_version in the startup handshake. Without this, psql-wire omits the
+	// parameter entirely (a honeypot tell — a real postgres always sends it). Must stay
+	// coherent with the `select version()` command_responses seed (PostgreSQL 14.11).
+	server.Version = serverVersion
 	port := os.Getenv("POSTGRES_PORT")
 	if port == "" {
 		port = "5432"

--- a/postgres/server_response.go
+++ b/postgres/server_response.go
@@ -15,6 +15,11 @@ import (
 // response lookup; anything longer skips the lookup and falls back to local handlers.
 const maxServerLookupLen = 4096
 
+// serverVersion is advertised in the pg startup handshake (server_version parameter). It is
+// the short form of the `select version()` command_responses seed and must stay coherent
+// with it — a mismatch between the handshake version and version() is a honeypot tell.
+const serverVersion = "14.11 (Ubuntu 14.11-0ubuntu0.22.04.1)"
+
 // getCommandResponse is an injectable seam over the gRPC call so the server-matched and
 // miss/error paths are unit-testable without a live server.
 var getCommandResponse = persistence.GetCommandResponse

--- a/postgres/server_response_test.go
+++ b/postgres/server_response_test.go
@@ -144,6 +144,18 @@ func TestLookupServerStatement(t *testing.T) {
 	}
 }
 
+// TestServerVersionSet pins the handshake server_version: it must be non-empty (an empty
+// value makes psql-wire omit the parameter, a honeypot tell) and carry the 14.11 version
+// that the `select version()` command_responses seed advertises, so the two stay coherent.
+func TestServerVersionSet(t *testing.T) {
+	if serverVersion == "" {
+		t.Fatal("serverVersion is empty — the pg handshake would omit server_version (a tell)")
+	}
+	if !strings.HasPrefix(serverVersion, "14.11") {
+		t.Fatalf("serverVersion = %q, want it to match the select version() seed (14.11)", serverVersion)
+	}
+}
+
 // compile-time assurance the fake satisfies the wire interface used by the framing code.
 var _ wire.DataWriter = (*fakeWriter)(nil)
 


### PR DESCRIPTION
Post-deploy fidelity check found the postgres honeypot omits the `server_version` startup ParameterStatus: `wire.NewServer` never sets `Server.Version`, and psql-wire only emits the param when it is non-empty. A real postgres always sends it, so its absence is a fingerprinting tell — and it is now incoherent with the `select version()` -> PostgreSQL 14.11 command_responses seed applied to prod.

Sets `server.Version = "14.11 (Ubuntu 14.11-0ubuntu0.22.04.1)"` (the short form matching `version()`), with a source-pin test guarding the coherence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)