### PR TITLE
feat: implement mongo + memcached honeypots (TGG)

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/joshrendek/threat.gg-agent/kafka"
 	"github.com/joshrendek/threat.gg-agent/kubernetes"
 	ldaphp "github.com/joshrendek/threat.gg-agent/ldap"
+	memcachedhp "github.com/joshrendek/threat.gg-agent/memcached"
+	mongohp "github.com/joshrendek/threat.gg-agent/mongo"
 	"github.com/joshrendek/threat.gg-agent/mqtt"
 	mysqlhp "github.com/joshrendek/threat.gg-agent/mysql"
 	"github.com/joshrendek/threat.gg-agent/openclaw"
@@ -20,10 +22,10 @@ import (
 	rdphp "github.com/joshrendek/threat.gg-agent/rdp"
 	redishp "github.com/joshrendek/threat.gg-agent/redis"
 	smbhp "github.com/joshrendek/threat.gg-agent/smb"
+	smtphp "github.com/joshrendek/threat.gg-agent/smtp"
 	"github.com/joshrendek/threat.gg-agent/sshd"
 	telnethp "github.com/joshrendek/threat.gg-agent/telnet"
 	"github.com/joshrendek/threat.gg-agent/updater"
-	smtphp "github.com/joshrendek/threat.gg-agent/smtp"
 	vnchp "github.com/joshrendek/threat.gg-agent/vnc"
 	"github.com/rs/zerolog/log"
 	"net/http"
@@ -111,6 +113,8 @@ func main() {
 	honeypots.Register(vnchp.New())
 	honeypots.Register(smtphp.New())
 	honeypots.Register(jenkins.New())
+	honeypots.Register(mongohp.New())
+	honeypots.Register(memcachedhp.New())
 	honeypots.StartHoneypots()
 
 	<-wait

--- a/memcached/memcached.go
+++ b/memcached/memcached.go
@@ -2,6 +2,7 @@ package memcached
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -83,6 +84,13 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	}
 
 	guid := uuid.NewV4().String()
+	// Backstop: a future slice-bounds bug in command/data-block handling must not take
+	// down every honeypot on the node.
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error().Interface("panic", r).Str("session", guid).Msg("recovered panic in memcached handler")
+		}
+	}()
 	h.logger.Info().Str("session", guid).Str("remote", host).Msg("new connection")
 
 	// A bare TCP connection to :11211 is itself a signal (memcached amplification
@@ -150,16 +158,23 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	h.logger.Info().Str("session", guid).Msg("session ended")
 }
 
-// readLine reads one CRLF/LF-terminated command line, rejecting an overlong line.
+// errLineTooLong signals a command line with no newline within the bounded buffer.
+var errLineTooLong = errors.New("memcached: command line exceeds buffer")
+
+// readLine reads one newline-terminated command line. It uses ReadSlice, which is bounded
+// by the bufio buffer (sized to maxLineLen), so a newline-free flood is rejected at the
+// buffer bound rather than accumulated in memory (ReadString would buffer the whole
+// stream first). The returned slice is copied into a string before the next read, so the
+// caller may retain it safely.
 func readLine(reader *bufio.Reader) (string, error) {
-	line, err := reader.ReadString('\n')
+	line, err := reader.ReadSlice('\n')
 	if err != nil {
+		if err == bufio.ErrBufferFull {
+			return "", errLineTooLong
+		}
 		return "", err
 	}
-	if len(line) > maxLineLen {
-		return "", io.ErrShortBuffer
-	}
-	return line, nil
+	return string(line), nil
 }
 
 // drainDataBlock consumes the n-byte payload plus its trailing CRLF that follows a

--- a/memcached/memcached.go
+++ b/memcached/memcached.go
@@ -1,0 +1,192 @@
+package memcached
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/cmdresp"
+	"github.com/joshrendek/threat.gg-agent/honeypots"
+	"github.com/joshrendek/threat.gg-agent/persistence"
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	defaultPort  = "11211"
+	idleTimeout  = 30 * time.Second
+	totalTimeout = 300 * time.Second
+	maxCommands  = 500
+
+	// maxLineLen caps a single command line so an unbounded write can't exhaust memory.
+	maxLineLen = 8 * 1024
+	// maxDataBlock caps the payload we drain after a storage command (real memcached
+	// default item size is 1MB); anything larger is refused with SERVER_ERROR.
+	maxDataBlock = 1 << 20
+)
+
+// Persistence seams — overridable in tests so the listener needs no live gRPC server.
+var (
+	saveMemcachedConnect = persistence.SaveMemcachedConnect
+	saveMemcachedCommand = persistence.SaveMemcachedCommand
+)
+
+var _ honeypots.Honeypot = &honeypot{}
+
+type honeypot struct {
+	logger zerolog.Logger
+}
+
+func New() honeypots.Honeypot {
+	return &honeypot{logger: zerolog.New(os.Stdout).With().Caller().Str("honeypot", "memcached").Logger()}
+}
+
+func (h *honeypot) Name() string {
+	return "memcached"
+}
+
+func (h *honeypot) Start() {
+	port := os.Getenv("MEMCACHED_HONEYPOT_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		h.logger.Fatal().Err(err).Msg("failed to start memcached listener")
+	}
+	h.logger.Info().Str("port", port).Msg("starting memcached honeypot")
+	h.serve(ln)
+}
+
+// serve runs the accept loop. Split from Start so tests can drive an ephemeral listener.
+func (h *honeypot) serve(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			h.logger.Error().Err(err).Msg("accept error")
+			return
+		}
+		go h.handleConnection(conn)
+	}
+}
+
+func (h *honeypot) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	host, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+	if host == "" {
+		host = conn.RemoteAddr().String()
+	}
+
+	guid := uuid.NewV4().String()
+	h.logger.Info().Str("session", guid).Str("remote", host).Msg("new connection")
+
+	// A bare TCP connection to :11211 is itself a signal (memcached amplification
+	// scanning), so record the connect up front. Protocol is the text/ascii protocol.
+	go h.persistConnect(host, guid)
+
+	conn.SetDeadline(time.Now().Add(totalTimeout))
+	reader := bufio.NewReaderSize(conn, maxLineLen)
+
+	for i := 0; i < maxCommands; i++ {
+		conn.SetReadDeadline(time.Now().Add(idleTimeout))
+
+		line, err := readLine(reader)
+		if err != nil {
+			break
+		}
+
+		cmd := parseCommand(line)
+
+		// A storage command is followed by a data block of the declared length; drain it
+		// so the payload is never parsed as the next command line.
+		if n, ok := cmd.storageDataBytes(); ok {
+			if n > maxDataBlock {
+				if _, werr := io.WriteString(conn, "SERVER_ERROR object too large for cache\r\n"); werr != nil {
+					break
+				}
+				// Best effort: skip the oversized payload without buffering it in memory.
+				if _, derr := io.CopyN(io.Discard, reader, int64(n)+2); derr != nil {
+					break
+				}
+				h.recordCommand(guid, cmd.raw)
+				continue
+			}
+			if err := drainDataBlock(reader, n); err != nil {
+				break
+			}
+		}
+
+		h.recordCommand(guid, cmd.raw)
+
+		h.logger.Debug().Str("session", guid).Str("command", cmd.name).Msg("command received")
+
+		// Server-authored response override (admin-editable command_responses, scoped to
+		// command_type="memcached"), keyed by the raw command line. On a Matched row we
+		// write it verbatim; on a miss/error we fall through to the hardcoded defaults so
+		// behavior never regresses when the server is unreachable.
+		if resp, ok := cmdresp.LookupAndRecord("memcached", cmd.raw, guid); ok {
+			if _, werr := io.WriteString(conn, resp); werr != nil {
+				break
+			}
+			continue
+		}
+
+		resp, closeConn := defaultResponse(cmd)
+		if resp != "" {
+			if _, werr := io.WriteString(conn, resp); werr != nil {
+				break
+			}
+		}
+		if closeConn {
+			break
+		}
+	}
+
+	h.logger.Info().Str("session", guid).Msg("session ended")
+}
+
+// readLine reads one CRLF/LF-terminated command line, rejecting an overlong line.
+func readLine(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	if len(line) > maxLineLen {
+		return "", io.ErrShortBuffer
+	}
+	return line, nil
+}
+
+// drainDataBlock consumes the n-byte payload plus its trailing CRLF that follows a
+// storage command, so it is not mistaken for the next command line.
+func drainDataBlock(reader *bufio.Reader, n int) error {
+	_, err := io.CopyN(io.Discard, reader, int64(n)+2)
+	return err
+}
+
+func (h *honeypot) recordCommand(guid, raw string) {
+	if raw == "" {
+		return
+	}
+	go func() {
+		if err := saveMemcachedCommand(&proto.MemcachedCommandRequest{Guid: guid, Command: raw}); err != nil {
+			h.logger.Error().Err(err).Str("session", guid).Msg("failed to persist memcached command")
+		}
+	}()
+}
+
+func (h *honeypot) persistConnect(host, guid string) {
+	req := &proto.MemcachedConnectRequest{
+		RemoteAddr: host,
+		Guid:       guid,
+		Protocol:   "ascii",
+	}
+	if err := saveMemcachedConnect(req); err != nil {
+		h.logger.Error().Err(err).Str("session", guid).Msg("failed to persist memcached connect")
+	}
+}

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -1,0 +1,179 @@
+package memcached
+
+import (
+	"bufio"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+)
+
+// recorder captures persistence calls under a mutex so tests can assert on them without
+// racing the honeypot's background goroutines.
+type recorder struct {
+	mu       sync.Mutex
+	connects []*proto.MemcachedConnectRequest
+	commands []*proto.MemcachedCommandRequest
+}
+
+func (r *recorder) addConnect(in *proto.MemcachedConnectRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.connects = append(r.connects, in)
+}
+
+func (r *recorder) addCommand(in *proto.MemcachedCommandRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.commands = append(r.commands, in)
+}
+
+func (r *recorder) connectSnapshot() []*proto.MemcachedConnectRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*proto.MemcachedConnectRequest(nil), r.connects...)
+}
+
+func (r *recorder) commandSnapshot() []*proto.MemcachedCommandRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*proto.MemcachedCommandRequest(nil), r.commands...)
+}
+
+// testRec is the single sink for persistence in tests. The seams are installed exactly
+// once (below) and never reassigned, so the honeypot's background goroutines can read
+// them without racing test teardown. Assertions are existence checks keyed on unique
+// per-test content, so the shared sink does not couple tests.
+var testRec = &recorder{}
+
+func init() {
+	saveMemcachedConnect = func(in *proto.MemcachedConnectRequest) error { testRec.addConnect(in); return nil }
+	saveMemcachedCommand = func(in *proto.MemcachedCommandRequest) error { testRec.addCommand(in); return nil }
+}
+
+// startTestServer spins up the real listener on an ephemeral port and returns its address.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	h := &honeypot{logger: zerolog.Nop()}
+	go h.serve(ln)
+
+	return ln.Addr().String()
+}
+
+func TestMemcachedVersionAndGet(t *testing.T) {
+	addr := startTestServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	r := bufio.NewReader(conn)
+
+	if _, err := conn.Write([]byte("version\r\n")); err != nil {
+		t.Fatalf("write version: %v", err)
+	}
+	line, err := r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read version reply: %v", err)
+	}
+	if len(line) < 8 || line[:8] != "VERSION " {
+		t.Fatalf("version reply = %q, want VERSION prefix", line)
+	}
+
+	if _, err := conn.Write([]byte("get foo\r\n")); err != nil {
+		t.Fatalf("write get: %v", err)
+	}
+	line, err = r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read get reply: %v", err)
+	}
+	if line != "END\r\n" {
+		t.Fatalf("get miss reply = %q, want END", line)
+	}
+}
+
+func TestMemcachedStorageDataBlockConsumed(t *testing.T) {
+	addr := startTestServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	r := bufio.NewReader(conn)
+
+	// A set carries a data block; the payload must NOT be parsed as the next command.
+	if _, err := conn.Write([]byte("set greeting 0 0 5\r\nhello\r\nversion\r\n")); err != nil {
+		t.Fatalf("write set: %v", err)
+	}
+	line, err := r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read stored: %v", err)
+	}
+	if line != "STORED\r\n" {
+		t.Fatalf("set reply = %q, want STORED", line)
+	}
+	line, err = r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read version after set: %v", err)
+	}
+	if len(line) < 8 || line[:8] != "VERSION " {
+		t.Fatalf("post-set reply = %q, want VERSION (data block leaked into parser)", line)
+	}
+
+	conn.Close()
+	waitFor(t, func() bool {
+		for _, c := range testRec.commandSnapshot() {
+			if c.Command == "set greeting 0 0 5" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestMemcachedPersistsConnect(t *testing.T) {
+	addr := startTestServer(t)
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	conn.Write([]byte("version\r\n"))
+	bufio.NewReader(conn).ReadString('\n')
+	conn.Close()
+
+	waitFor(t, func() bool {
+		for _, c := range testRec.connectSnapshot() {
+			if c.Protocol == "ascii" && c.Guid != "" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}

--- a/memcached/memcached_test.go
+++ b/memcached/memcached_test.go
@@ -2,6 +2,8 @@ package memcached
 
 import (
 	"bufio"
+	"bytes"
+	"io"
 	"net"
 	"sync"
 	"testing"
@@ -164,6 +166,34 @@ func TestMemcachedPersistsConnect(t *testing.T) {
 		}
 		return false
 	})
+}
+
+// countingReader records how many bytes were pulled from the underlying stream.
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += n
+	return n, err
+}
+
+// TestReadLineRejectsOverlongLine is the regression for unbounded line buffering: a long
+// newline-free flood must be rejected at the buffer bound, not accumulated. bufio's size
+// alone does NOT bound ReadString, so this asserts on bytes actually consumed.
+func TestReadLineRejectsOverlongLine(t *testing.T) {
+	flood := bytes.Repeat([]byte{'A'}, maxLineLen*8)
+	cr := &countingReader{r: bytes.NewReader(flood)}
+	reader := bufio.NewReaderSize(cr, maxLineLen)
+
+	if _, err := readLine(reader); err == nil {
+		t.Fatal("readLine(overlong flood): err = nil, want an overlong-line error")
+	}
+	if cr.n > maxLineLen {
+		t.Fatalf("readLine consumed %d bytes, want <= %d (it must not buffer the whole flood)", cr.n, maxLineLen)
+	}
 }
 
 func waitFor(t *testing.T, cond func() bool) {

--- a/memcached/protocol.go
+++ b/memcached/protocol.go
@@ -1,0 +1,182 @@
+package memcached
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// serverVersion is reported by `version` and the `stats` block. Kept consistent so a
+// scanner fingerprinting the banner and the stats output sees the same build.
+const serverVersion = "1.6.21"
+
+// fakeItems are enticing keys a scanner may stumble onto with `get`; every value is
+// obviously fabricated honeypot bait. Anything not listed here is a miss (END).
+var fakeItems = map[string]string{
+	"session":       `{"user_id":1,"role":"admin","token":"eyJhbGciOiJIUzI1NiJ9.fake"}`,
+	"user:1:token":  "tok_8f3a2b1c4d5e6f7a8b9c0d1e2f3a4b5c",
+	"config:db_dsn": "postgres://admin:s3cret@10.0.1.5:5432/production",
+	"api_key":       "rk_live_HONEYPOT_FAKE_KEY_0000000",
+}
+
+// command is a parsed memcached text-protocol request line.
+type command struct {
+	name string   // lowercased verb (e.g. "get", "set", "stats")
+	args []string // remaining whitespace-separated tokens
+	raw  string   // original line with CR/LF trimmed
+}
+
+// parseCommand splits a single memcached text-protocol line into a verb and its args.
+// The verb is lowercased; args preserve their original casing (keys are case-sensitive).
+func parseCommand(line string) command {
+	line = strings.TrimRight(line, "\r\n")
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return command{raw: line}
+	}
+	return command{name: strings.ToLower(fields[0]), args: fields[1:], raw: line}
+}
+
+var storageCommands = map[string]bool{
+	"set": true, "add": true, "replace": true, "append": true, "prepend": true, "cas": true,
+}
+
+// isStorageCommand reports whether the verb is followed by a data block on the wire.
+func isStorageCommand(name string) bool {
+	return storageCommands[name]
+}
+
+// storageDataBytes returns the declared payload length for a storage command. For every
+// storage verb the <bytes> field is the 4th argument (key, flags, exptime, bytes, ...),
+// including `cas` whose trailing cas-unique token comes after <bytes>.
+func (c command) storageDataBytes() (int, bool) {
+	if !isStorageCommand(c.name) || len(c.args) < 4 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(c.args[3])
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// hasNoReply reports whether the client appended the "noreply" token, which suppresses
+// the storage acknowledgement.
+func (c command) hasNoReply() bool {
+	return len(c.args) > 0 && c.args[len(c.args)-1] == "noreply"
+}
+
+// defaultResponse returns the hardcoded canned reply for a parsed command and whether the
+// connection should be closed afterwards. It is only consulted when no admin-authored
+// command_responses row matched (see the connection loop).
+func defaultResponse(c command) (response string, closeConn bool) {
+	switch c.name {
+	case "":
+		return "ERROR\r\n", false
+	case "version":
+		return "VERSION " + serverVersion + "\r\n", false
+	case "quit":
+		return "", true
+	case "get", "gets":
+		return getResponse(c), false
+	case "set", "add", "replace", "append", "prepend", "cas":
+		if c.hasNoReply() {
+			return "", false
+		}
+		return "STORED\r\n", false
+	case "delete":
+		if len(c.args) > 0 {
+			if _, ok := fakeItems[c.args[0]]; ok {
+				return "DELETED\r\n", false
+			}
+		}
+		return "NOT_FOUND\r\n", false
+	case "incr", "decr":
+		return "NOT_FOUND\r\n", false
+	case "touch":
+		return "NOT_FOUND\r\n", false
+	case "flush_all":
+		return "OK\r\n", false
+	case "verbosity":
+		return "OK\r\n", false
+	case "stats":
+		return statsResponse(c), false
+	default:
+		return "ERROR\r\n", false
+	}
+}
+
+// getResponse renders VALUE blocks for any requested keys that exist in fakeItems and
+// always terminates with END, matching real memcached (misses simply produce END).
+func getResponse(c command) string {
+	var sb strings.Builder
+	for _, key := range c.args {
+		if val, ok := fakeItems[key]; ok {
+			fmt.Fprintf(&sb, "VALUE %s 0 %d\r\n%s\r\n", key, len(val), val)
+		}
+	}
+	sb.WriteString("END\r\n")
+	return sb.String()
+}
+
+// statsResponse renders the STAT block for `stats`, `stats items`, and `stats slabs`.
+// Every variant terminates with END like the real server.
+func statsResponse(c command) string {
+	sub := ""
+	if len(c.args) > 0 {
+		sub = strings.ToLower(c.args[0])
+	}
+	switch sub {
+	case "items":
+		return "STAT items:1:number 3\r\n" +
+			"STAT items:1:age 620\r\n" +
+			"STAT items:1:evicted 0\r\n" +
+			"STAT items:1:outofmemory 0\r\n" +
+			"END\r\n"
+	case "slabs":
+		return "STAT 1:chunk_size 96\r\n" +
+			"STAT 1:chunks_per_page 10922\r\n" +
+			"STAT 1:total_pages 1\r\n" +
+			"STAT 1:used_chunks 3\r\n" +
+			"STAT active_slabs 1\r\n" +
+			"STAT total_malloced 1048512\r\n" +
+			"END\r\n"
+	case "":
+		return generalStats()
+	default:
+		// Unknown stats subcommand: real memcached returns just END.
+		return "END\r\n"
+	}
+}
+
+func generalStats() string {
+	now := time.Now().Unix()
+	var sb strings.Builder
+	stats := [][2]string{
+		{"pid", "2342"},
+		{"uptime", "1892734"},
+		{"time", strconv.FormatInt(now, 10)},
+		{"version", serverVersion},
+		{"pointer_size", "64"},
+		{"curr_connections", "5"},
+		{"total_connections", "1023"},
+		{"cmd_get", "48213"},
+		{"cmd_set", "12030"},
+		{"get_hits", "39217"},
+		{"get_misses", "8996"},
+		{"delete_hits", "12"},
+		{"delete_misses", "40"},
+		{"curr_items", "1523"},
+		{"total_items", "88123"},
+		{"bytes", "4587213"},
+		{"limit_maxbytes", "67108864"},
+		{"threads", "4"},
+		{"evictions", "0"},
+	}
+	for _, kv := range stats {
+		fmt.Fprintf(&sb, "STAT %s %s\r\n", kv[0], kv[1])
+	}
+	sb.WriteString("END\r\n")
+	return sb.String()
+}

--- a/memcached/protocol_test.go
+++ b/memcached/protocol_test.go
@@ -1,0 +1,145 @@
+package memcached
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		wantName string
+		wantArgs []string
+	}{
+		{"version", "version", "version", nil},
+		{"uppercased verb is lowercased", "VERSION", "version", nil},
+		{"trailing cr stripped", "version\r", "version", nil},
+		{"get with key", "get foo", "get", []string{"foo"}},
+		{"gets multi key", "gets a b c", "gets", []string{"a", "b", "c"}},
+		{"stats subcommand", "stats items", "stats", []string{"items"}},
+		{"set with meta", "set k 0 0 5", "set", []string{"k", "0", "0", "5"}},
+		{"empty line", "", "", nil},
+		{"whitespace collapses", "get   foo", "get", []string{"foo"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCommand(tt.line)
+			if got.name != tt.wantName {
+				t.Errorf("name = %q, want %q", got.name, tt.wantName)
+			}
+			if len(got.args) != len(tt.wantArgs) {
+				t.Fatalf("args = %v, want %v", got.args, tt.wantArgs)
+			}
+			for i := range tt.wantArgs {
+				if got.args[i] != tt.wantArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, got.args[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsStorageCommand(t *testing.T) {
+	for _, name := range []string{"set", "add", "replace", "append", "prepend", "cas"} {
+		if !isStorageCommand(name) {
+			t.Errorf("isStorageCommand(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"get", "gets", "delete", "stats", "version", "quit", ""} {
+		if isStorageCommand(name) {
+			t.Errorf("isStorageCommand(%q) = true, want false", name)
+		}
+	}
+}
+
+func TestStorageDataBytes(t *testing.T) {
+	// set <key> <flags> <exptime> <bytes> [noreply]
+	c := parseCommand("set mykey 0 3600 10")
+	n, ok := c.storageDataBytes()
+	if !ok || n != 10 {
+		t.Fatalf("storageDataBytes = (%d,%v), want (10,true)", n, ok)
+	}
+
+	// cas has an extra cas-unique token but <bytes> is still the 4th arg
+	c = parseCommand("cas mykey 0 3600 7 42")
+	n, ok = c.storageDataBytes()
+	if !ok || n != 7 {
+		t.Fatalf("cas storageDataBytes = (%d,%v), want (7,true)", n, ok)
+	}
+
+	// malformed / missing bytes field
+	c = parseCommand("set mykey 0 0")
+	if _, ok := c.storageDataBytes(); ok {
+		t.Fatal("storageDataBytes ok=true for malformed set, want false")
+	}
+}
+
+func TestHasNoReply(t *testing.T) {
+	if !parseCommand("set k 0 0 5 noreply").hasNoReply() {
+		t.Fatal("noreply not detected")
+	}
+	if parseCommand("set k 0 0 5").hasNoReply() {
+		t.Fatal("noreply falsely detected")
+	}
+}
+
+func TestDefaultResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantPrefix  string
+		wantClose   bool
+		wantExactfn func(string) bool
+	}{
+		{name: "version", line: "version", wantPrefix: "VERSION "},
+		{name: "get miss returns END", line: "get foo", wantExactfn: func(s string) bool { return s == "END\r\n" }},
+		{name: "gets miss returns END", line: "gets nope", wantExactfn: func(s string) bool { return s == "END\r\n" }},
+		{name: "unknown command returns ERROR", line: "bogus", wantExactfn: func(s string) bool { return s == "ERROR\r\n" }},
+		{name: "empty command returns ERROR", line: "", wantExactfn: func(s string) bool { return s == "ERROR\r\n" }},
+		{name: "set returns STORED", line: "set k 0 0 5", wantExactfn: func(s string) bool { return s == "STORED\r\n" }},
+		{name: "set noreply is silent", line: "set k 0 0 5 noreply", wantExactfn: func(s string) bool { return s == "" }},
+		{name: "flush_all returns OK", line: "flush_all", wantExactfn: func(s string) bool { return s == "OK\r\n" }},
+		{name: "delete miss returns NOT_FOUND", line: "delete foo", wantExactfn: func(s string) bool { return s == "NOT_FOUND\r\n" }},
+		{name: "quit closes", line: "quit", wantClose: true, wantExactfn: func(s string) bool { return s == "" }},
+		{name: "stats ends with END", line: "stats", wantExactfn: func(s string) bool { return strings.HasSuffix(s, "END\r\n") && strings.Contains(s, "STAT ") }},
+		{name: "stats items ends with END", line: "stats items", wantExactfn: func(s string) bool { return strings.HasSuffix(s, "END\r\n") }},
+		{name: "stats slabs ends with END", line: "stats slabs", wantExactfn: func(s string) bool { return strings.HasSuffix(s, "END\r\n") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, closeConn := defaultResponse(parseCommand(tt.line))
+			if closeConn != tt.wantClose {
+				t.Errorf("closeConn = %v, want %v", closeConn, tt.wantClose)
+			}
+			if tt.wantPrefix != "" && !strings.HasPrefix(resp, tt.wantPrefix) {
+				t.Errorf("resp = %q, want prefix %q", resp, tt.wantPrefix)
+			}
+			if tt.wantExactfn != nil && !tt.wantExactfn(resp) {
+				t.Errorf("resp = %q failed expectation", resp)
+			}
+		})
+	}
+}
+
+// A get on a known enticing key returns a VALUE block terminated by END so
+// scanners that dump keys see plausible loot.
+func TestGetKnownKeyReturnsValue(t *testing.T) {
+	var hitKey string
+	for k := range fakeItems {
+		hitKey = k
+		break
+	}
+	if hitKey == "" {
+		t.Skip("no fake items defined")
+	}
+	resp, _ := defaultResponse(parseCommand("get " + hitKey))
+	if !strings.HasPrefix(resp, "VALUE "+hitKey+" ") {
+		t.Errorf("resp = %q, want VALUE block for %q", resp, hitKey)
+	}
+	if !strings.HasSuffix(resp, "END\r\n") {
+		t.Errorf("resp = %q, want END terminator", resp)
+	}
+}

--- a/mongo/bson.go
+++ b/mongo/bson.go
@@ -151,9 +151,22 @@ func (d bsonDocument) firstKey() string {
 
 var errBSON = errors.New("malformed bson")
 
+// maxBSONDepth bounds document nesting. Matches MongoDB's own limit and, crucially, stops
+// a maliciously deep document (reachable unauthenticated over the wire) from recursing
+// until the goroutine stack overflows — an uncatchable fatal error that would take down
+// every honeypot on the node.
+const maxBSONDepth = 100
+
 // decodeDocument parses a complete BSON document. It validates the declared length and
 // every field's bounds so attacker-supplied data can't drive an over-read or panic.
 func decodeDocument(data []byte) (bsonDocument, error) {
+	return decodeDocumentDepth(data, 0)
+}
+
+func decodeDocumentDepth(data []byte, depth int) (bsonDocument, error) {
+	if depth > maxBSONDepth {
+		return nil, errBSON
+	}
 	if len(data) < 5 {
 		return nil, errBSON
 	}
@@ -177,7 +190,7 @@ func decodeDocument(data []byte) (bsonDocument, error) {
 		}
 		pos += n
 
-		val, consumed, err := decodeValue(etype, body[pos:])
+		val, consumed, err := decodeValue(etype, body[pos:], depth)
 		if err != nil {
 			return nil, err
 		}
@@ -196,7 +209,7 @@ func readCString(b []byte) (string, int, error) {
 	return "", 0, errBSON
 }
 
-func decodeValue(etype byte, b []byte) (bsonValue, int, error) {
+func decodeValue(etype byte, b []byte, depth int) (bsonValue, int, error) {
 	switch etype {
 	case bsonTypeDouble:
 		if len(b) < 8 {
@@ -221,7 +234,7 @@ func decodeValue(etype byte, b []byte) (bsonValue, int, error) {
 		if dlen < 5 || dlen > len(b) {
 			return bsonValue{}, 0, errBSON
 		}
-		sub, err := decodeDocument(b[:dlen])
+		sub, err := decodeDocumentDepth(b[:dlen], depth+1)
 		if err != nil {
 			return bsonValue{}, 0, err
 		}

--- a/mongo/bson.go
+++ b/mongo/bson.go
@@ -1,0 +1,267 @@
+package mongo
+
+import (
+	"encoding/binary"
+	"errors"
+	"math"
+	"time"
+)
+
+// BSON element type bytes (subset needed by the honeypot).
+const (
+	bsonTypeDouble   = 0x01
+	bsonTypeString   = 0x02
+	bsonTypeDocument = 0x03
+	bsonTypeBinary   = 0x05
+	bsonTypeBool     = 0x08
+	bsonTypeDateTime = 0x09
+	bsonTypeNull     = 0x0A
+	bsonTypeInt32    = 0x10
+	bsonTypeInt64    = 0x12
+)
+
+// bsonBuilder accumulates BSON elements in insertion order and frames them into a
+// complete document on build(). It is deliberately minimal — only the element types the
+// honeypot emits are supported. Order is preserved so the emitted document reads like a
+// real server response (ismaster first, ok last, etc.).
+type bsonBuilder struct {
+	elems []byte
+}
+
+func (b *bsonBuilder) key(t byte, name string) {
+	b.elems = append(b.elems, t)
+	b.elems = append(b.elems, name...)
+	b.elems = append(b.elems, 0x00)
+}
+
+func (b *bsonBuilder) addDouble(name string, v float64) {
+	b.key(bsonTypeDouble, name)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], math.Float64bits(v))
+	b.elems = append(b.elems, buf[:]...)
+}
+
+func (b *bsonBuilder) addString(name, v string) {
+	b.key(bsonTypeString, name)
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(len(v)+1))
+	b.elems = append(b.elems, buf[:]...)
+	b.elems = append(b.elems, v...)
+	b.elems = append(b.elems, 0x00)
+}
+
+func (b *bsonBuilder) addBool(name string, v bool) {
+	b.key(bsonTypeBool, name)
+	if v {
+		b.elems = append(b.elems, 0x01)
+	} else {
+		b.elems = append(b.elems, 0x00)
+	}
+}
+
+func (b *bsonBuilder) addInt32(name string, v int32) {
+	b.key(bsonTypeInt32, name)
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(v))
+	b.elems = append(b.elems, buf[:]...)
+}
+
+func (b *bsonBuilder) addInt64(name string, v int64) {
+	b.key(bsonTypeInt64, name)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(v))
+	b.elems = append(b.elems, buf[:]...)
+}
+
+func (b *bsonBuilder) addDateTime(name string, t time.Time) {
+	b.key(bsonTypeDateTime, name)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(t.UnixMilli()))
+	b.elems = append(b.elems, buf[:]...)
+}
+
+// addDoc appends a nested document. sub must be a complete document (as returned by
+// build()).
+func (b *bsonBuilder) addDoc(name string, sub []byte) {
+	b.key(bsonTypeDocument, name)
+	b.elems = append(b.elems, sub...)
+}
+
+// addBinary appends a generic (subtype 0x00) binary value.
+func (b *bsonBuilder) addBinary(name string, v []byte) {
+	b.key(bsonTypeBinary, name)
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], uint32(len(v)))
+	b.elems = append(b.elems, buf[:]...)
+	b.elems = append(b.elems, 0x00) // subtype: generic
+	b.elems = append(b.elems, v...)
+}
+
+// build frames the accumulated elements into a complete BSON document:
+// int32 total length, elements, trailing 0x00.
+func (b *bsonBuilder) build() []byte {
+	total := 4 + len(b.elems) + 1
+	out := make([]byte, 0, total)
+	var lenBuf [4]byte
+	binary.LittleEndian.PutUint32(lenBuf[:], uint32(total))
+	out = append(out, lenBuf[:]...)
+	out = append(out, b.elems...)
+	out = append(out, 0x00)
+	return out
+}
+
+// bsonValue is a decoded BSON value. Only the field matching Type is meaningful.
+type bsonValue struct {
+	Type byte
+	d    float64
+	str  string
+	b    bool
+	dt   time.Time
+	i32  int32
+	i64  int64
+	bin  []byte
+	doc  bsonDocument
+}
+
+type bsonElement struct {
+	Key   string
+	Value bsonValue
+}
+
+// bsonDocument is a decoded document preserving element order.
+type bsonDocument []bsonElement
+
+func (d bsonDocument) lookup(key string) (bsonValue, bool) {
+	for _, e := range d {
+		if e.Key == key {
+			return e.Value, true
+		}
+	}
+	return bsonValue{}, false
+}
+
+// firstKey returns the key of the first element, which for a command document names the
+// command. Empty when the document has no elements.
+func (d bsonDocument) firstKey() string {
+	if len(d) == 0 {
+		return ""
+	}
+	return d[0].Key
+}
+
+var errBSON = errors.New("malformed bson")
+
+// decodeDocument parses a complete BSON document. It validates the declared length and
+// every field's bounds so attacker-supplied data can't drive an over-read or panic.
+func decodeDocument(data []byte) (bsonDocument, error) {
+	if len(data) < 5 {
+		return nil, errBSON
+	}
+	total := int(binary.LittleEndian.Uint32(data[0:4]))
+	if total < 5 || total > len(data) {
+		return nil, errBSON
+	}
+	body := data[4 : total-1] // exclude length prefix and trailing null
+	if data[total-1] != 0x00 {
+		return nil, errBSON
+	}
+
+	var doc bsonDocument
+	pos := 0
+	for pos < len(body) {
+		etype := body[pos]
+		pos++
+		name, n, err := readCString(body[pos:])
+		if err != nil {
+			return nil, err
+		}
+		pos += n
+
+		val, consumed, err := decodeValue(etype, body[pos:])
+		if err != nil {
+			return nil, err
+		}
+		pos += consumed
+		doc = append(doc, bsonElement{Key: name, Value: val})
+	}
+	return doc, nil
+}
+
+func readCString(b []byte) (string, int, error) {
+	for i := 0; i < len(b); i++ {
+		if b[i] == 0x00 {
+			return string(b[:i]), i + 1, nil
+		}
+	}
+	return "", 0, errBSON
+}
+
+func decodeValue(etype byte, b []byte) (bsonValue, int, error) {
+	switch etype {
+	case bsonTypeDouble:
+		if len(b) < 8 {
+			return bsonValue{}, 0, errBSON
+		}
+		return bsonValue{Type: etype, d: math.Float64frombits(binary.LittleEndian.Uint64(b[:8]))}, 8, nil
+	case bsonTypeString:
+		if len(b) < 4 {
+			return bsonValue{}, 0, errBSON
+		}
+		slen := int(binary.LittleEndian.Uint32(b[:4]))
+		if slen < 1 || 4+slen > len(b) {
+			return bsonValue{}, 0, errBSON
+		}
+		// slen includes the trailing null.
+		return bsonValue{Type: etype, str: string(b[4 : 4+slen-1])}, 4 + slen, nil
+	case bsonTypeDocument:
+		if len(b) < 4 {
+			return bsonValue{}, 0, errBSON
+		}
+		dlen := int(binary.LittleEndian.Uint32(b[:4]))
+		if dlen < 5 || dlen > len(b) {
+			return bsonValue{}, 0, errBSON
+		}
+		sub, err := decodeDocument(b[:dlen])
+		if err != nil {
+			return bsonValue{}, 0, err
+		}
+		return bsonValue{Type: etype, doc: sub}, dlen, nil
+	case bsonTypeBinary:
+		if len(b) < 5 {
+			return bsonValue{}, 0, errBSON
+		}
+		blen := int(binary.LittleEndian.Uint32(b[:4]))
+		if blen < 0 || 5+blen > len(b) {
+			return bsonValue{}, 0, errBSON
+		}
+		// b[4] is the subtype; skip it and copy the payload.
+		payload := append([]byte(nil), b[5:5+blen]...)
+		return bsonValue{Type: etype, bin: payload}, 5 + blen, nil
+	case bsonTypeBool:
+		if len(b) < 1 {
+			return bsonValue{}, 0, errBSON
+		}
+		return bsonValue{Type: etype, b: b[0] != 0x00}, 1, nil
+	case bsonTypeDateTime:
+		if len(b) < 8 {
+			return bsonValue{}, 0, errBSON
+		}
+		ms := int64(binary.LittleEndian.Uint64(b[:8]))
+		return bsonValue{Type: etype, dt: time.UnixMilli(ms).UTC()}, 8, nil
+	case bsonTypeNull:
+		return bsonValue{Type: etype}, 0, nil
+	case bsonTypeInt32:
+		if len(b) < 4 {
+			return bsonValue{}, 0, errBSON
+		}
+		return bsonValue{Type: etype, i32: int32(binary.LittleEndian.Uint32(b[:4]))}, 4, nil
+	case bsonTypeInt64:
+		if len(b) < 8 {
+			return bsonValue{}, 0, errBSON
+		}
+		return bsonValue{Type: etype, i64: int64(binary.LittleEndian.Uint64(b[:8]))}, 8, nil
+	default:
+		// Unknown/unsupported type: we can't know its length, so we cannot safely continue.
+		return bsonValue{}, 0, errBSON
+	}
+}

--- a/mongo/bson_test.go
+++ b/mongo/bson_test.go
@@ -1,0 +1,106 @@
+package mongo
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// TestEncodeOkExactBytes pins the wire encoding of a minimal {"ok": 1.0} document so a
+// refactor that breaks BSON framing fails loudly.
+func TestEncodeOkExactBytes(t *testing.T) {
+	var b bsonBuilder
+	b.addDouble("ok", 1.0)
+	got := b.build()
+
+	want := []byte{
+		0x11, 0x00, 0x00, 0x00, // int32 total length = 17
+		0x01,             // type: double
+		0x6F, 0x6B, 0x00, // cstring "ok"
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, // float64 1.0 LE
+		0x00, // document terminator
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("encode {ok:1.0}\n got  %x\n want %x", got, want)
+	}
+}
+
+// TestEncodeDecodeRoundTrip builds a document with every type the honeypot emits or reads,
+// then decodes it back and checks each value survives the round trip.
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	now := time.Unix(1700000000, 0).UTC()
+
+	var sub bsonBuilder
+	sub.addString("name", "mongo-go-driver")
+	sub.addString("version", "1.13.1")
+
+	var b bsonBuilder
+	b.addBool("ismaster", true)
+	b.addInt32("maxWireVersion", 21)
+	b.addInt64("counter", 9000000000)
+	b.addString("version", "7.0.5")
+	b.addDateTime("localTime", now)
+	b.addDouble("ok", 1.0)
+	b.addDoc("driver", sub.build())
+	b.addBinary("payload", []byte{0x01, 0x02, 0x03})
+
+	doc, err := decodeDocument(b.build())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if v, ok := doc.lookup("ismaster"); !ok || v.b != true {
+		t.Errorf("ismaster = %v (ok=%v), want true", v.b, ok)
+	}
+	if v, ok := doc.lookup("maxWireVersion"); !ok || v.i32 != 21 {
+		t.Errorf("maxWireVersion = %v, want 21", v.i32)
+	}
+	if v, ok := doc.lookup("counter"); !ok || v.i64 != 9000000000 {
+		t.Errorf("counter = %v, want 9000000000", v.i64)
+	}
+	if v, ok := doc.lookup("version"); !ok || v.str != "7.0.5" {
+		t.Errorf("version = %q, want 7.0.5", v.str)
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Errorf("ok = %v, want 1.0", v.d)
+	}
+	if v, ok := doc.lookup("localTime"); !ok || v.dt.UTC() != now {
+		t.Errorf("localTime = %v, want %v", v.dt, now)
+	}
+	if v, ok := doc.lookup("payload"); !ok || !bytes.Equal(v.bin, []byte{0x01, 0x02, 0x03}) {
+		t.Errorf("payload = %x, want 010203", v.bin)
+	}
+
+	sv, ok := doc.lookup("driver")
+	if !ok {
+		t.Fatal("driver subdocument missing")
+	}
+	if dv, ok := sv.doc.lookup("version"); !ok || dv.str != "1.13.1" {
+		t.Errorf("driver.version = %q, want 1.13.1", dv.str)
+	}
+}
+
+// TestFirstKey exercises command-name extraction: the first element key names the command.
+func TestFirstKey(t *testing.T) {
+	var b bsonBuilder
+	b.addInt32("hello", 1)
+	b.addInt32("helloOk", 1)
+	doc, err := decodeDocument(b.build())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got := doc.firstKey(); got != "hello" {
+		t.Fatalf("firstKey = %q, want hello", got)
+	}
+}
+
+// TestDecodeRejectsTruncated ensures a malformed length header is rejected rather than
+// panicking or over-reading.
+func TestDecodeRejectsTruncated(t *testing.T) {
+	if _, err := decodeDocument([]byte{0x20, 0x00, 0x00, 0x00, 0x01}); err == nil {
+		t.Fatal("decode truncated document: err = nil, want error")
+	}
+	if _, err := decodeDocument([]byte{0x03}); err == nil {
+		t.Fatal("decode short buffer: err = nil, want error")
+	}
+}

--- a/mongo/bson_test.go
+++ b/mongo/bson_test.go
@@ -104,3 +104,31 @@ func TestDecodeRejectsTruncated(t *testing.T) {
 		t.Fatal("decode short buffer: err = nil, want error")
 	}
 }
+
+// TestDecodeRejectsDeepNesting is the regression for the unbounded-recursion crash: a BSON
+// document nested past the depth cap (reachable unauthenticated via OP_MSG/OP_QUERY) must
+// return an error, not recurse until the goroutine stack overflows (which recover() cannot
+// catch and which would kill every honeypot on the node). The depth used here is safely
+// small; the guard, not the stack, must reject it.
+func TestDecodeRejectsDeepNesting(t *testing.T) {
+	inner := (&bsonBuilder{}).build() // {}
+	for i := 0; i < maxBSONDepth+5; i++ {
+		var b bsonBuilder
+		b.addDoc("a", inner)
+		inner = b.build()
+	}
+	if _, err := decodeDocument(inner); err == nil {
+		t.Fatal("decode over-deep document: err = nil, want error")
+	}
+
+	// A document nested within the cap must still decode cleanly.
+	shallow := (&bsonBuilder{}).build()
+	for i := 0; i < 10; i++ {
+		var b bsonBuilder
+		b.addDoc("a", shallow)
+		shallow = b.build()
+	}
+	if _, err := decodeDocument(shallow); err != nil {
+		t.Fatalf("decode within-cap document: %v", err)
+	}
+}

--- a/mongo/commands.go
+++ b/mongo/commands.go
@@ -1,0 +1,174 @@
+package mongo
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	// serverVersion is the fake MongoDB version advertised by buildInfo and hello.
+	serverVersion = "7.0.5"
+	// maxWireVersion 21 corresponds to MongoDB 7.x, so modern drivers speak OP_MSG.
+	maxWireVersion      = 21
+	maxBsonObjectSize   = 16 * 1024 * 1024
+	maxMessageSizeBytes = 48000000
+	maxWriteBatchSize   = 100000
+)
+
+// helloResponse builds the BSON body for isMaster/hello/ismaster. It advertises a
+// standalone writable primary running a modern wire version so drivers proceed to
+// authenticate (where we capture credentials). Both the legacy `ismaster` and modern
+// `isWritablePrimary` fields are set for compatibility across driver generations, and a
+// fake `version` string is included to satisfy banner fingerprinters.
+func helloResponse() []byte {
+	var b bsonBuilder
+	b.addBool("ismaster", true)
+	b.addBool("isWritablePrimary", true)
+	b.addBool("helloOk", true)
+	b.addInt32("maxBsonObjectSize", maxBsonObjectSize)
+	b.addInt32("maxMessageSizeBytes", maxMessageSizeBytes)
+	b.addInt32("maxWriteBatchSize", maxWriteBatchSize)
+	b.addDateTime("localTime", time.Now().UTC())
+	b.addInt32("logicalSessionTimeoutMinutes", 30)
+	b.addInt32("connectionId", 17)
+	b.addInt32("minWireVersion", 0)
+	b.addInt32("maxWireVersion", maxWireVersion)
+	b.addBool("readOnly", false)
+	b.addString("version", serverVersion)
+	b.addDouble("ok", 1.0)
+	return b.build()
+}
+
+// buildInfoResponse answers the buildInfo command with a plausible version document.
+func buildInfoResponse() []byte {
+	var b bsonBuilder
+	b.addString("version", serverVersion)
+	b.addString("gitVersion", "1b3b0e5b3a0c5e0d9f2a1c4b6e8d7f0a2c4e6b8d")
+	b.addString("sysInfo", "deprecated")
+	b.addBool("debug", false)
+	b.addInt32("bits", 64)
+	b.addInt32("maxBsonObjectSize", maxBsonObjectSize)
+	b.addDouble("ok", 1.0)
+	return b.build()
+}
+
+// okResponse is the generic {ok: 1.0} acknowledgement.
+func okResponse() []byte {
+	var b bsonBuilder
+	b.addDouble("ok", 1.0)
+	return b.build()
+}
+
+// authFailedResponse mimics MongoDB's reply to invalid credentials so a scanner records a
+// realistic "auth required, creds rejected" outcome after we have captured the attempt.
+func authFailedResponse() []byte {
+	var b bsonBuilder
+	b.addDouble("ok", 0.0)
+	b.addString("errmsg", "Authentication failed.")
+	b.addInt32("code", 18)
+	b.addString("codeName", "AuthenticationFailed")
+	return b.build()
+}
+
+// commandResponse selects the BSON body to reply with for a parsed command document.
+func commandResponse(cmdName string, doc bsonDocument) []byte {
+	switch strings.ToLower(cmdName) {
+	case "ismaster", "hello":
+		return helloResponse()
+	case "buildinfo":
+		return buildInfoResponse()
+	case "saslstart", "saslcontinue", "authenticate":
+		return authFailedResponse()
+	default:
+		// ping, whatsmyuri, getnonce, listDatabases, and anything else: keep the attacker
+		// engaged with a bare success rather than tipping them off with an error.
+		return okResponse()
+	}
+}
+
+// extractCredentials pulls a best-effort username/password/mechanism out of an auth
+// command. SCRAM hides the password (only the username appears in the client-first
+// message); PLAIN carries both in the SASL payload; legacy authenticate carries the
+// username directly.
+func extractCredentials(cmdName string, doc bsonDocument) (username, password, mechanism string) {
+	if v, ok := doc.lookup("mechanism"); ok {
+		mechanism = v.str
+	}
+
+	switch strings.ToLower(cmdName) {
+	case "authenticate":
+		if v, ok := doc.lookup("user"); ok {
+			username = v.str
+		}
+		return username, password, mechanism
+	case "saslstart":
+		payload, ok := doc.lookup("payload")
+		if !ok {
+			return username, password, mechanism
+		}
+		if strings.EqualFold(mechanism, "PLAIN") {
+			username, password = parsePlainPayload(payload.bin)
+		} else {
+			username = parseScramUsername(payload.bin)
+		}
+	}
+	return username, password, mechanism
+}
+
+// parsePlainPayload decodes a SASL PLAIN payload: authzid \x00 authcid \x00 passwd.
+func parsePlainPayload(payload []byte) (user, pass string) {
+	parts := strings.Split(string(payload), "\x00")
+	if len(parts) >= 3 {
+		return parts[1], parts[2]
+	}
+	return "", ""
+}
+
+// parseScramUsername extracts the username from a SCRAM client-first message. The payload
+// is "<gs2-header>n=<user>,r=<nonce>"; we read the first n= attribute after the header.
+func parseScramUsername(payload []byte) string {
+	s := string(payload)
+	// Strip the gs2 header ("n,,", "y,,", or "p=tls-...,,") up to the first ",,".
+	if idx := strings.Index(s, ",,"); idx != -1 {
+		s = s[idx+2:]
+	}
+	for _, attr := range strings.Split(s, ",") {
+		if strings.HasPrefix(attr, "n=") {
+			// SCRAM encodes '=' as =3D and ',' as =2C in usernames; reverse that.
+			name := strings.TrimPrefix(attr, "n=")
+			name = strings.ReplaceAll(name, "=2C", ",")
+			name = strings.ReplaceAll(name, "=3D", "=")
+			return name
+		}
+	}
+	return ""
+}
+
+// extractClientVersion reads the driver identity from the hello client metadata
+// (client.driver.name + version), used to populate MongoConnectRequest.ClientVersion.
+func extractClientVersion(doc bsonDocument) string {
+	client, ok := doc.lookup("client")
+	if !ok || client.Type != bsonTypeDocument {
+		return ""
+	}
+	driver, ok := client.doc.lookup("driver")
+	if !ok || driver.Type != bsonTypeDocument {
+		// Fall back to the application name if there is no driver block.
+		if app, ok := client.doc.lookup("application"); ok && app.Type == bsonTypeDocument {
+			if name, ok := app.doc.lookup("name"); ok {
+				return name.str
+			}
+		}
+		return ""
+	}
+	name, _ := driver.doc.lookup("name")
+	version, _ := driver.doc.lookup("version")
+	switch {
+	case name.str != "" && version.str != "":
+		return name.str + " " + version.str
+	case name.str != "":
+		return name.str
+	default:
+		return version.str
+	}
+}

--- a/mongo/commands_test.go
+++ b/mongo/commands_test.go
@@ -1,0 +1,172 @@
+package mongo
+
+import "testing"
+
+func decodeOrFail(t *testing.T, raw []byte) bsonDocument {
+	t.Helper()
+	doc, err := decodeDocument(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return doc
+}
+
+func TestHelloResponseFields(t *testing.T) {
+	doc := decodeOrFail(t, helloResponse())
+
+	if v, ok := doc.lookup("ismaster"); !ok || !v.b {
+		t.Errorf("ismaster = %v, want true", v.b)
+	}
+	if v, ok := doc.lookup("isWritablePrimary"); !ok || !v.b {
+		t.Errorf("isWritablePrimary = %v, want true", v.b)
+	}
+	if v, ok := doc.lookup("maxWireVersion"); !ok || v.i32 != 21 {
+		t.Errorf("maxWireVersion = %d, want 21", v.i32)
+	}
+	if v, ok := doc.lookup("maxBsonObjectSize"); !ok || v.i32 != 16*1024*1024 {
+		t.Errorf("maxBsonObjectSize = %d, want 16MiB", v.i32)
+	}
+	if v, ok := doc.lookup("maxMessageSizeBytes"); !ok || v.i32 != 48000000 {
+		t.Errorf("maxMessageSizeBytes = %d", v.i32)
+	}
+	if _, ok := doc.lookup("localTime"); !ok {
+		t.Error("localTime missing")
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Errorf("ok = %v, want 1.0", v.d)
+	}
+}
+
+func TestBuildInfoResponseHasVersion(t *testing.T) {
+	doc := decodeOrFail(t, buildInfoResponse())
+	if v, ok := doc.lookup("version"); !ok || v.str != serverVersion {
+		t.Errorf("version = %q, want %q", v.str, serverVersion)
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Errorf("ok = %v, want 1.0", v.d)
+	}
+}
+
+func TestExtractCredentialsScram(t *testing.T) {
+	var b bsonBuilder
+	b.addInt32("saslStart", 1)
+	b.addString("mechanism", "SCRAM-SHA-256")
+	b.addBinary("payload", []byte("n,,n=root,r=rOprNGfwEbeRWgbNEkqO"))
+	doc := decodeOrFail(t, b.build())
+
+	user, pass, mech := extractCredentials("saslStart", doc)
+	if user != "root" {
+		t.Errorf("user = %q, want root", user)
+	}
+	if pass != "" {
+		t.Errorf("pass = %q, want empty (scram hides password)", pass)
+	}
+	if mech != "SCRAM-SHA-256" {
+		t.Errorf("mech = %q", mech)
+	}
+}
+
+func TestExtractCredentialsPlain(t *testing.T) {
+	var b bsonBuilder
+	b.addInt32("saslStart", 1)
+	b.addString("mechanism", "PLAIN")
+	b.addBinary("payload", []byte("\x00admin\x00s3cr3t"))
+	doc := decodeOrFail(t, b.build())
+
+	user, pass, _ := extractCredentials("saslStart", doc)
+	if user != "admin" {
+		t.Errorf("user = %q, want admin", user)
+	}
+	if pass != "s3cr3t" {
+		t.Errorf("pass = %q, want s3cr3t", pass)
+	}
+}
+
+func TestExtractCredentialsAuthenticate(t *testing.T) {
+	var b bsonBuilder
+	b.addInt32("authenticate", 1)
+	b.addString("user", "dbadmin")
+	b.addString("mechanism", "MONGODB-X509")
+	doc := decodeOrFail(t, b.build())
+
+	user, _, mech := extractCredentials("authenticate", doc)
+	if user != "dbadmin" {
+		t.Errorf("user = %q, want dbadmin", user)
+	}
+	if mech != "MONGODB-X509" {
+		t.Errorf("mech = %q", mech)
+	}
+}
+
+func TestExtractClientVersion(t *testing.T) {
+	var driver bsonBuilder
+	driver.addString("name", "mongo-go-driver")
+	driver.addString("version", "1.13.1")
+
+	var client bsonBuilder
+	client.addDoc("driver", driver.build())
+
+	var b bsonBuilder
+	b.addInt32("hello", 1)
+	b.addDoc("client", client.build())
+	doc := decodeOrFail(t, b.build())
+
+	if got := extractClientVersion(doc); got != "mongo-go-driver 1.13.1" {
+		t.Errorf("clientVersion = %q, want 'mongo-go-driver 1.13.1'", got)
+	}
+
+	// Absent client metadata yields empty string, not a panic.
+	empty := decodeOrFail(t, (&bsonBuilder{}).build())
+	if got := extractClientVersion(empty); got != "" {
+		t.Errorf("clientVersion(empty) = %q, want empty", got)
+	}
+}
+
+func TestCommandResponseDispatch(t *testing.T) {
+	tests := []struct {
+		cmd    string
+		verify func(t *testing.T, doc bsonDocument)
+	}{
+		{"hello", func(t *testing.T, doc bsonDocument) {
+			if v, ok := doc.lookup("ismaster"); !ok || !v.b {
+				t.Error("hello: ismaster not true")
+			}
+		}},
+		{"isMaster", func(t *testing.T, doc bsonDocument) {
+			if v, ok := doc.lookup("ismaster"); !ok || !v.b {
+				t.Error("isMaster: ismaster not true")
+			}
+		}},
+		{"ping", func(t *testing.T, doc bsonDocument) {
+			if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+				t.Error("ping: ok != 1.0")
+			}
+		}},
+		{"buildInfo", func(t *testing.T, doc bsonDocument) {
+			if v, ok := doc.lookup("version"); !ok || v.str != serverVersion {
+				t.Error("buildInfo: version missing")
+			}
+		}},
+		{"saslStart", func(t *testing.T, doc bsonDocument) {
+			if v, ok := doc.lookup("ok"); !ok || v.d != 0.0 {
+				t.Error("saslStart: ok should be 0 (auth failed)")
+			}
+			if _, ok := doc.lookup("errmsg"); !ok {
+				t.Error("saslStart: errmsg missing")
+			}
+		}},
+		{"whatsmyuri", func(t *testing.T, doc bsonDocument) {
+			if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+				t.Error("whatsmyuri: ok != 1.0")
+			}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cmd, func(t *testing.T) {
+			var b bsonBuilder
+			b.addInt32(tt.cmd, 1)
+			body := commandResponse(tt.cmd, decodeOrFail(t, b.build()))
+			tt.verify(t, decodeOrFail(t, body))
+		})
+	}
+}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -93,6 +93,14 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	}
 
 	sess := &session{guid: uuid.NewV4().String(), remoteIP: host}
+	// Backstop: a slice-bounds bug in future wire/BSON parsing must not take down every
+	// honeypot on the node. Registered before persistSession so it also covers a panic
+	// during persistence. (This does NOT cover stack overflow — the BSON depth cap does.)
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error().Interface("panic", r).Str("session", sess.guid).Msg("recovered panic in mongo handler")
+		}
+	}()
 	defer h.persistSession(sess)
 
 	h.logger.Info().Str("session", sess.guid).Str("remote", host).Msg("new connection")
@@ -154,7 +162,7 @@ func (h *honeypot) dispatch(header msgHeader, payload []byte, sess *session) ([]
 		}
 		cmdName := doc.firstKey()
 		ns := ""
-		if db, ok := doc.lookup("$db"); ok {
+		if db, ok := doc.lookup("$db"); ok && db.Type == bsonTypeString {
 			ns = db.str
 		}
 		h.observe(sess, cmdName, ns, doc)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -1,0 +1,235 @@
+package mongo
+
+import (
+	"bufio"
+	"encoding/binary"
+	"io"
+	"net"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/honeypots"
+	"github.com/joshrendek/threat.gg-agent/persistence"
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	defaultPort  = "27017"
+	idleTimeout  = 30 * time.Second
+	totalTimeout = 300 * time.Second
+	maxMessages  = 200
+)
+
+// Persistence seams — overridable in tests so the listener needs no live gRPC server.
+var (
+	saveMongoConnect = persistence.SaveMongoConnect
+	saveMongoCommand = persistence.SaveMongoCommand
+)
+
+// requestCounter feeds the responseTo-independent requestID we stamp on replies.
+var requestCounter int32
+
+var _ honeypots.Honeypot = &honeypot{}
+
+type honeypot struct {
+	logger zerolog.Logger
+}
+
+func New() honeypots.Honeypot {
+	return &honeypot{logger: zerolog.New(os.Stdout).With().Caller().Str("honeypot", "mongodb").Logger()}
+}
+
+func (h *honeypot) Name() string {
+	return "mongodb"
+}
+
+func (h *honeypot) Start() {
+	port := os.Getenv("MONGO_HONEYPOT_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	ln, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		h.logger.Fatal().Err(err).Msg("failed to start mongodb listener")
+	}
+	h.logger.Info().Str("port", port).Msg("starting mongodb honeypot")
+	h.serve(ln)
+}
+
+// serve runs the accept loop. Split from Start so tests can drive an ephemeral listener.
+func (h *honeypot) serve(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			h.logger.Error().Err(err).Msg("accept error")
+			return
+		}
+		go h.handleConnection(conn)
+	}
+}
+
+// session accumulates what we learned across one connection. Credentials and the driver
+// version trickle in across separate commands (hello, then saslStart), so we persist the
+// connect once at the end with the best values seen.
+type session struct {
+	guid          string
+	remoteIP      string
+	username      string
+	password      string
+	clientVersion string
+	commands      []string
+}
+
+func (h *honeypot) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	host, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+	if host == "" {
+		host = conn.RemoteAddr().String()
+	}
+
+	sess := &session{guid: uuid.NewV4().String(), remoteIP: host}
+	defer h.persistSession(sess)
+
+	h.logger.Info().Str("session", sess.guid).Str("remote", host).Msg("new connection")
+
+	conn.SetDeadline(time.Now().Add(totalTimeout))
+	reader := bufio.NewReader(conn)
+
+	for i := 0; i < maxMessages; i++ {
+		conn.SetReadDeadline(time.Now().Add(idleTimeout))
+
+		header, payload, err := readMessage(reader)
+		if err != nil {
+			break
+		}
+
+		reply, err := h.dispatch(header, payload, sess)
+		if err != nil {
+			h.logger.Debug().Err(err).Str("session", sess.guid).Msg("dispatch error")
+			break
+		}
+		if reply == nil {
+			continue
+		}
+		if _, err := conn.Write(reply); err != nil {
+			break
+		}
+	}
+
+	h.logger.Info().Str("session", sess.guid).Int("commands", len(sess.commands)).Msg("session ended")
+}
+
+// dispatch parses one wire message, updates the session, and returns the bytes to write
+// back (nil to write nothing). Unknown opcodes end the session.
+func (h *honeypot) dispatch(header msgHeader, payload []byte, sess *session) ([]byte, error) {
+	replyID := atomic.AddInt32(&requestCounter, 1)
+
+	switch header.opCode {
+	case opQuery:
+		collection, query, err := parseOpQuery(payload)
+		if err != nil {
+			return nil, err
+		}
+		doc, err := decodeDocument(query)
+		if err != nil {
+			return nil, err
+		}
+		cmdName := doc.firstKey()
+		h.observe(sess, cmdName, collection, doc)
+		return buildOpReply(replyID, header.requestID, commandResponse(cmdName, doc)), nil
+
+	case opMsg:
+		body, err := parseOpMsg(payload)
+		if err != nil {
+			return nil, err
+		}
+		doc, err := decodeDocument(body)
+		if err != nil {
+			return nil, err
+		}
+		cmdName := doc.firstKey()
+		ns := ""
+		if db, ok := doc.lookup("$db"); ok {
+			ns = db.str
+		}
+		h.observe(sess, cmdName, ns, doc)
+		return buildOpMsgReply(replyID, header.requestID, commandResponse(cmdName, doc)), nil
+
+	default:
+		return nil, errWire
+	}
+}
+
+// observe records the command and harvests credentials / driver metadata into the session.
+func (h *honeypot) observe(sess *session, cmdName, namespace string, doc bsonDocument) {
+	label := cmdName
+	if namespace != "" {
+		label = cmdName + " " + namespace
+	}
+	sess.commands = append(sess.commands, label)
+
+	if cv := extractClientVersion(doc); cv != "" {
+		sess.clientVersion = cv
+	}
+
+	switch cmdName {
+	case "saslStart", "saslContinue", "authenticate":
+		user, pass, _ := extractCredentials(cmdName, doc)
+		if user != "" {
+			sess.username = user
+		}
+		if pass != "" {
+			sess.password = pass
+		}
+	}
+}
+
+// readMessage reads one complete wire message, validating the declared length so a hostile
+// length prefix cannot drive an unbounded allocation.
+func readMessage(r *bufio.Reader) (msgHeader, []byte, error) {
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(r, lenBuf[:]); err != nil {
+		return msgHeader{}, nil, err
+	}
+	total := int(binary.LittleEndian.Uint32(lenBuf[:]))
+	if total < headerLen || total > maxMessageLen {
+		return msgHeader{}, nil, errWire
+	}
+	buf := make([]byte, total)
+	copy(buf, lenBuf[:])
+	if _, err := io.ReadFull(r, buf[4:]); err != nil {
+		return msgHeader{}, nil, err
+	}
+	header, err := parseHeader(buf[:headerLen])
+	if err != nil {
+		return msgHeader{}, nil, err
+	}
+	return header, buf[headerLen:], nil
+}
+
+func (h *honeypot) persistSession(sess *session) {
+	// A connection to :27017 is itself a scan signal, so record the connect even without
+	// captured credentials.
+	connectReq := &proto.MongoConnectRequest{
+		RemoteAddr:    sess.remoteIP,
+		Guid:          sess.guid,
+		Username:      sess.username,
+		Password:      sess.password,
+		ClientVersion: sess.clientVersion,
+	}
+	if err := saveMongoConnect(connectReq); err != nil {
+		h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist mongo connect")
+		return
+	}
+
+	for _, cmd := range sess.commands {
+		if err := saveMongoCommand(&proto.MongoCommandRequest{Guid: sess.guid, Command: cmd}); err != nil {
+			h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist mongo command")
+		}
+	}
+}

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,7 +1,10 @@
 package mongo
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"sync"
@@ -35,6 +38,12 @@ func (r *recorder) connectSnapshot() []*proto.MongoConnectRequest {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return append([]*proto.MongoConnectRequest(nil), r.connects...)
+}
+
+func (r *recorder) commandSnapshot() []*proto.MongoCommandRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*proto.MongoCommandRequest(nil), r.commands...)
 }
 
 // testRec is the single persistence sink, installed once so background goroutines never
@@ -172,6 +181,52 @@ func TestMongoOpQueryIsMaster(t *testing.T) {
 	}
 }
 
+// TestMongoNonStringDbIgnored checks the $db type guard: a $db field sent as a non-string
+// must not be read as a namespace (it is simply ignored), and the command still succeeds.
+func TestMongoNonStringDbIgnored(t *testing.T) {
+	addr := startTestServer(t)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	var b bsonBuilder
+	b.addInt32("ping", 1)
+	b.addInt32("$db", 123) // hostile: $db is not a string
+	if _, err := conn.Write(buildClientOpMsg(42, b.build())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h, payload := readReply(t, conn)
+	if h.opCode != opMsg {
+		t.Fatalf("reply opCode = %d, want OP_MSG", h.opCode)
+	}
+	body, err := parseOpMsg(payload)
+	if err != nil {
+		t.Fatalf("parseOpMsg: %v", err)
+	}
+	doc, err := decodeDocument(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Fatalf("ok = %v, want 1.0", v.d)
+	}
+	conn.Close()
+
+	// The recorded command must be the bare command name, with no namespace appended.
+	waitFor(t, func() bool {
+		for _, c := range testRec.commandSnapshot() {
+			if c.Command == "ping" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
 func TestMongoCapturesPlainCredentials(t *testing.T) {
 	addr := startTestServer(t)
 	conn, err := net.Dial("tcp", addr)
@@ -201,6 +256,66 @@ func TestMongoCapturesPlainCredentials(t *testing.T) {
 		}
 		return false
 	})
+}
+
+// TestMongoHandlerRecoversFromPanic is the regression for the recover backstop: a panic
+// raised on a downstream path (here, persistence) must be caught by the handler's
+// deferred recover rather than escaping the goroutine and crashing the whole agent
+// process (an unrecovered goroutine panic terminates every honeypot on the node).
+func TestMongoHandlerRecoversFromPanic(t *testing.T) {
+	called := make(chan struct{}, 1)
+	orig := saveMongoConnect
+	saveMongoConnect = func(*proto.MongoConnectRequest) error {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		panic("boom from persistence")
+	}
+	t.Cleanup(func() { saveMongoConnect = orig })
+
+	addr := startTestServer(t)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	var b bsonBuilder
+	b.addInt32("hello", 1)
+	if _, err := conn.Write(buildClientOpMsg(1, b.build())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readReply(t, conn) // a valid reply is still served before the connection closes
+	conn.Close()
+
+	select {
+	case <-called:
+		// The panicking seam ran inside persistSession; without the handler's recover
+		// this goroutine panic would have crashed the test binary.
+	case <-time.After(2 * time.Second):
+		t.Fatal("persistence seam was never invoked")
+	}
+	time.Sleep(50 * time.Millisecond) // let the deferred recover run
+}
+
+// TestMongoRejectsOversizedMessage is the regression for the up-front full-message
+// allocation: a hostile 4-byte length prefix declaring a huge message must be rejected
+// before any body read or `make([]byte, total)`, and the accepted cap must stay small so
+// stalled connections can't each pin a large buffer.
+func TestMongoRejectsOversizedMessage(t *testing.T) {
+	if maxMessageLen > 2*1024*1024 {
+		t.Fatalf("maxMessageLen = %d, want <= 2MiB to bound the up-front allocation", maxMessageLen)
+	}
+
+	header := make([]byte, 4)
+	binary.LittleEndian.PutUint32(header, uint32(maxMessageLen+1))
+	// Only the length prefix is provided: if the cap were checked before the body read,
+	// no body read is attempted and we get errWire — not a read error from a giant buffer.
+	r := bufio.NewReader(bytes.NewReader(header))
+	if _, _, err := readMessage(r); !errors.Is(err, errWire) {
+		t.Fatalf("readMessage(oversized) err = %v, want errWire", err)
+	}
 }
 
 func waitFor(t *testing.T, cond func() bool) {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,0 +1,216 @@
+package mongo
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+)
+
+// recorder captures persistence calls under a mutex.
+type recorder struct {
+	mu       sync.Mutex
+	connects []*proto.MongoConnectRequest
+	commands []*proto.MongoCommandRequest
+}
+
+func (r *recorder) addConnect(in *proto.MongoConnectRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.connects = append(r.connects, in)
+}
+
+func (r *recorder) addCommand(in *proto.MongoCommandRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.commands = append(r.commands, in)
+}
+
+func (r *recorder) connectSnapshot() []*proto.MongoConnectRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*proto.MongoConnectRequest(nil), r.connects...)
+}
+
+// testRec is the single persistence sink, installed once so background goroutines never
+// race test teardown. Assertions key on unique per-test content.
+var testRec = &recorder{}
+
+func init() {
+	saveMongoConnect = func(in *proto.MongoConnectRequest) error { testRec.addConnect(in); return nil }
+	saveMongoCommand = func(in *proto.MongoCommandRequest) error { testRec.addCommand(in); return nil }
+}
+
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	h := &honeypot{logger: zerolog.Nop()}
+	go h.serve(ln)
+	return ln.Addr().String()
+}
+
+// buildClientOpMsg frames a full client OP_MSG (header + payload).
+func buildClientOpMsg(requestID int32, body []byte) []byte {
+	payload := buildOpMsgRequest(body)
+	total := headerLen + len(payload)
+	out := appendHeader(nil, int32(total), requestID, 0, opMsg)
+	return append(out, payload...)
+}
+
+// buildClientOpQuery frames a full client OP_QUERY (header + payload).
+func buildClientOpQuery(requestID int32, collection string, query []byte) []byte {
+	payload := make([]byte, 4) // flags
+	payload = append(payload, collection...)
+	payload = append(payload, 0x00)
+	payload = append(payload, make([]byte, 8)...) // skip + return
+	payload = append(payload, query...)
+	total := headerLen + len(payload)
+	out := appendHeader(nil, int32(total), requestID, 0, opQuery)
+	return append(out, payload...)
+}
+
+// readReply reads one full wire message from the connection.
+func readReply(t *testing.T, conn net.Conn) (msgHeader, []byte) {
+	t.Helper()
+	var lenBuf [4]byte
+	if _, err := io.ReadFull(conn, lenBuf[:]); err != nil {
+		t.Fatalf("read length: %v", err)
+	}
+	total := int(binary.LittleEndian.Uint32(lenBuf[:]))
+	if total < headerLen || total > maxMessageLen {
+		t.Fatalf("reply length %d out of range", total)
+	}
+	buf := make([]byte, total)
+	copy(buf, lenBuf[:])
+	if _, err := io.ReadFull(conn, buf[4:]); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	h, err := parseHeader(buf[:16])
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	return h, buf[16:]
+}
+
+func TestMongoOpMsgHello(t *testing.T) {
+	addr := startTestServer(t)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	var b bsonBuilder
+	b.addInt32("hello", 1)
+	b.addString("$db", "admin")
+	if _, err := conn.Write(buildClientOpMsg(1, b.build())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h, payload := readReply(t, conn)
+	if h.opCode != opMsg {
+		t.Fatalf("reply opCode = %d, want OP_MSG", h.opCode)
+	}
+	if h.responseTo != 1 {
+		t.Fatalf("responseTo = %d, want 1", h.responseTo)
+	}
+	body, err := parseOpMsg(payload)
+	if err != nil {
+		t.Fatalf("parseOpMsg: %v", err)
+	}
+	doc, err := decodeDocument(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Fatalf("ok = %v, want 1.0", v.d)
+	}
+	if v, ok := doc.lookup("ismaster"); !ok || !v.b {
+		t.Fatalf("ismaster = %v, want true", v.b)
+	}
+}
+
+func TestMongoOpQueryIsMaster(t *testing.T) {
+	addr := startTestServer(t)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	var q bsonBuilder
+	q.addInt32("isMaster", 1)
+	if _, err := conn.Write(buildClientOpQuery(9, "admin.$cmd", q.build())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	h, payload := readReply(t, conn)
+	if h.opCode != opReply {
+		t.Fatalf("reply opCode = %d, want OP_REPLY", h.opCode)
+	}
+	if h.responseTo != 9 {
+		t.Fatalf("responseTo = %d, want 9", h.responseTo)
+	}
+	// OP_REPLY body starts 20 bytes into the payload.
+	doc, err := decodeDocument(payload[20:])
+	if err != nil {
+		t.Fatalf("decode OP_REPLY body: %v", err)
+	}
+	if v, ok := doc.lookup("ismaster"); !ok || !v.b {
+		t.Fatalf("ismaster = %v, want true", v.b)
+	}
+}
+
+func TestMongoCapturesPlainCredentials(t *testing.T) {
+	addr := startTestServer(t)
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+
+	var b bsonBuilder
+	b.addInt32("saslStart", 1)
+	b.addString("mechanism", "PLAIN")
+	b.addBinary("payload", []byte("\x00sa\x00hunter2"))
+	b.addString("$db", "admin")
+	if _, err := conn.Write(buildClientOpMsg(3, b.build())); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Drain the auth-failed reply.
+	readReply(t, conn)
+	conn.Close()
+
+	waitFor(t, func() bool {
+		for _, c := range testRec.connectSnapshot() {
+			if c.Username == "sa" && c.Password == "hunter2" {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}

--- a/mongo/wire.go
+++ b/mongo/wire.go
@@ -14,9 +14,12 @@ const (
 
 const (
 	headerLen = 16
-	// maxMessageLen bounds a single wire message so a malicious length prefix cannot
-	// drive an unbounded allocation. Matches the advertised maxMessageSizeBytes.
-	maxMessageLen = 48 * 1000 * 1000
+	// maxMessageLen bounds a single accepted wire message so a hostile 4-byte length
+	// prefix cannot drive a large up-front allocation pinned across a stalled connection.
+	// A honeypot never needs to accept large messages (real handshakes are well under a
+	// KB), so this is intentionally far below the advertised maxMessageSizeBytes — the
+	// value we *claim* to support (commands.go) and the value we *accept* are independent.
+	maxMessageLen = 1 << 20 // 1 MiB
 )
 
 var errWire = errors.New("malformed mongo wire message")

--- a/mongo/wire.go
+++ b/mongo/wire.go
@@ -1,0 +1,143 @@
+package mongo
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// MongoDB wire-protocol opcodes (the subset this honeypot understands).
+const (
+	opReply = 1    // response to a legacy OP_QUERY
+	opQuery = 2004 // legacy query (isMaster handshake)
+	opMsg   = 2013 // modern command message
+)
+
+const (
+	headerLen = 16
+	// maxMessageLen bounds a single wire message so a malicious length prefix cannot
+	// drive an unbounded allocation. Matches the advertised maxMessageSizeBytes.
+	maxMessageLen = 48 * 1000 * 1000
+)
+
+var errWire = errors.New("malformed mongo wire message")
+
+// msgHeader is the 16-byte MongoDB wire-protocol message header.
+type msgHeader struct {
+	messageLength int32
+	requestID     int32
+	responseTo    int32
+	opCode        int32
+}
+
+// parseHeader decodes the 16-byte wire header (little-endian).
+func parseHeader(b []byte) (msgHeader, error) {
+	if len(b) < headerLen {
+		return msgHeader{}, errWire
+	}
+	return msgHeader{
+		messageLength: int32(binary.LittleEndian.Uint32(b[0:4])),
+		requestID:     int32(binary.LittleEndian.Uint32(b[4:8])),
+		responseTo:    int32(binary.LittleEndian.Uint32(b[8:12])),
+		opCode:        int32(binary.LittleEndian.Uint32(b[12:16])),
+	}, nil
+}
+
+// parseOpMsg returns the kind-0 body document bytes from an OP_MSG payload (the bytes
+// after the 16-byte header). Kind-1 document sequences are skipped; a trailing checksum,
+// if present, is harmless because scanning stops at the body section.
+func parseOpMsg(payload []byte) ([]byte, error) {
+	if len(payload) < 4 {
+		return nil, errWire
+	}
+	pos := 4 // skip flagBits
+	for pos < len(payload) {
+		kind := payload[pos]
+		pos++
+		switch kind {
+		case 0: // body: a single document
+			return readEmbeddedDoc(payload[pos:])
+		case 1: // document sequence: int32 size (incl. itself) + cstring + docs
+			if pos+4 > len(payload) {
+				return nil, errWire
+			}
+			size := int(binary.LittleEndian.Uint32(payload[pos : pos+4]))
+			if size < 4 || pos+size > len(payload) {
+				return nil, errWire
+			}
+			pos += size
+		default:
+			return nil, errWire
+		}
+	}
+	return nil, errWire
+}
+
+// readEmbeddedDoc slices out one complete BSON document from the front of b using its own
+// length prefix, validating bounds.
+func readEmbeddedDoc(b []byte) ([]byte, error) {
+	if len(b) < 4 {
+		return nil, errWire
+	}
+	dlen := int(binary.LittleEndian.Uint32(b[:4]))
+	if dlen < 5 || dlen > len(b) {
+		return nil, errWire
+	}
+	return b[:dlen], nil
+}
+
+// parseOpQuery extracts the fullCollectionName and the query document from an OP_QUERY
+// payload (the bytes after the 16-byte header):
+// flags int32, fullCollectionName cstring, numberToSkip int32, numberToReturn int32, query.
+func parseOpQuery(payload []byte) (string, []byte, error) {
+	if len(payload) < 4 {
+		return "", nil, errWire
+	}
+	pos := 4 // skip flags
+	name, n, err := readCString(payload[pos:])
+	if err != nil {
+		return "", nil, err
+	}
+	pos += n
+	pos += 8 // numberToSkip + numberToReturn
+	if pos > len(payload) {
+		return "", nil, errWire
+	}
+	query, err := readEmbeddedDoc(payload[pos:])
+	if err != nil {
+		return "", nil, err
+	}
+	return name, query, nil
+}
+
+// buildOpMsgReply frames a body document as an OP_MSG reply (flagBits 0, single kind-0
+// section), echoing responseTo so the client correlates it to its request.
+func buildOpMsgReply(requestID, responseTo int32, body []byte) []byte {
+	total := headerLen + 4 + 1 + len(body)
+	out := make([]byte, 0, total)
+	out = appendHeader(out, int32(total), requestID, responseTo, opMsg)
+	out = binary.LittleEndian.AppendUint32(out, 0) // flagBits
+	out = append(out, 0x00)                        // section kind: body
+	out = append(out, body...)
+	return out
+}
+
+// buildOpReply frames a body document as a legacy OP_REPLY answering an OP_QUERY.
+func buildOpReply(requestID, responseTo int32, body []byte) []byte {
+	total := headerLen + 4 + 8 + 4 + 4 + len(body)
+	out := make([]byte, 0, total)
+	out = appendHeader(out, int32(total), requestID, responseTo, opReply)
+	out = binary.LittleEndian.AppendUint32(out, 0) // responseFlags
+	out = binary.LittleEndian.AppendUint64(out, 0) // cursorID
+	out = binary.LittleEndian.AppendUint32(out, 0) // startingFrom
+	out = binary.LittleEndian.AppendUint32(out, 1) // numberReturned
+	out = append(out, body...)
+	return out
+}
+
+func appendHeader(out []byte, messageLength, requestID, responseTo, opCode int32) []byte {
+	out = binary.LittleEndian.AppendUint32(out, uint32(messageLength))
+	out = binary.LittleEndian.AppendUint32(out, uint32(requestID))
+	out = binary.LittleEndian.AppendUint32(out, uint32(responseTo))
+	out = binary.LittleEndian.AppendUint32(out, uint32(opCode))
+	return out
+}

--- a/mongo/wire_test.go
+++ b/mongo/wire_test.go
@@ -1,0 +1,189 @@
+package mongo
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseHeader(t *testing.T) {
+	raw := make([]byte, 16)
+	binary.LittleEndian.PutUint32(raw[0:], 40)    // messageLength
+	binary.LittleEndian.PutUint32(raw[4:], 7)     // requestID
+	binary.LittleEndian.PutUint32(raw[8:], 0)     // responseTo
+	binary.LittleEndian.PutUint32(raw[12:], 2013) // opCode (OP_MSG)
+
+	h, err := parseHeader(raw)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if h.messageLength != 40 || h.requestID != 7 || h.responseTo != 0 || h.opCode != opMsg {
+		t.Fatalf("header = %+v", h)
+	}
+
+	if _, err := parseHeader(raw[:10]); err == nil {
+		t.Fatal("parseHeader(short): err = nil, want error")
+	}
+}
+
+// buildOpMsgRequest frames a body document as a client OP_MSG request payload (the bytes
+// after the 16-byte header): flagBits + section kind 0 + body.
+func buildOpMsgRequest(body []byte) []byte {
+	payload := make([]byte, 4) // flagBits = 0
+	payload = append(payload, 0x00)
+	payload = append(payload, body...)
+	return payload
+}
+
+func TestParseOpMsgExtractsBody(t *testing.T) {
+	var b bsonBuilder
+	b.addInt32("hello", 1)
+	b.addString("saslSupportedMechs", "admin.root")
+	body := b.build()
+
+	got, err := parseOpMsg(buildOpMsgRequest(body))
+	if err != nil {
+		t.Fatalf("parseOpMsg: %v", err)
+	}
+	doc, err := decodeDocument(got)
+	if err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if doc.firstKey() != "hello" {
+		t.Fatalf("firstKey = %q, want hello", doc.firstKey())
+	}
+}
+
+// A kind-1 document sequence preceding the body must be skipped, not mis-parsed.
+func TestParseOpMsgSkipsDocumentSequence(t *testing.T) {
+	var seqDoc bsonBuilder
+	seqDoc.addInt32("q", 1)
+	seq := seqDoc.build()
+
+	identifier := "documents\x00"
+	size := 4 + len(identifier) + len(seq)
+	payload := make([]byte, 4) // flagBits
+	payload = append(payload, 0x01)
+	sizeBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
+	payload = append(payload, sizeBuf...)
+	payload = append(payload, identifier...)
+	payload = append(payload, seq...)
+
+	var body bsonBuilder
+	body.addInt32("insert", 1)
+	payload = append(payload, 0x00)
+	payload = append(payload, body.build()...)
+
+	got, err := parseOpMsg(payload)
+	if err != nil {
+		t.Fatalf("parseOpMsg: %v", err)
+	}
+	doc, err := decodeDocument(got)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if doc.firstKey() != "insert" {
+		t.Fatalf("firstKey = %q, want insert", doc.firstKey())
+	}
+}
+
+func TestParseOpQuery(t *testing.T) {
+	var q bsonBuilder
+	q.addInt32("isMaster", 1)
+	query := q.build()
+
+	payload := make([]byte, 4) // flags
+	payload = append(payload, "admin.$cmd\x00"...)
+	skip := make([]byte, 8) // numberToSkip + numberToReturn
+	payload = append(payload, skip...)
+	payload = append(payload, query...)
+
+	collection, gotQuery, err := parseOpQuery(payload)
+	if err != nil {
+		t.Fatalf("parseOpQuery: %v", err)
+	}
+	if collection != "admin.$cmd" {
+		t.Fatalf("collection = %q, want admin.$cmd", collection)
+	}
+	doc, err := decodeDocument(gotQuery)
+	if err != nil {
+		t.Fatalf("decode query: %v", err)
+	}
+	if doc.firstKey() != "isMaster" {
+		t.Fatalf("firstKey = %q, want isMaster", doc.firstKey())
+	}
+}
+
+// TestBuildOpMsgReplyRoundTrip frames a body as an OP_MSG reply, then re-parses the header
+// and body to confirm the whole message is well-formed and echoes responseTo.
+func TestBuildOpMsgReplyRoundTrip(t *testing.T) {
+	var b bsonBuilder
+	b.addBool("ismaster", true)
+	b.addDouble("ok", 1.0)
+	body := b.build()
+
+	msg := buildOpMsgReply(11, 7, body)
+
+	if int(binary.LittleEndian.Uint32(msg[0:4])) != len(msg) {
+		t.Fatalf("messageLength = %d, want %d", binary.LittleEndian.Uint32(msg[0:4]), len(msg))
+	}
+	h, err := parseHeader(msg[:16])
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if h.opCode != opMsg {
+		t.Fatalf("opCode = %d, want OP_MSG", h.opCode)
+	}
+	if h.responseTo != 7 {
+		t.Fatalf("responseTo = %d, want 7", h.responseTo)
+	}
+
+	bodyBytes, err := parseOpMsg(msg[16:])
+	if err != nil {
+		t.Fatalf("parseOpMsg reply: %v", err)
+	}
+	doc, err := decodeDocument(bodyBytes)
+	if err != nil {
+		t.Fatalf("decode reply body: %v", err)
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Fatalf("reply ok = %v, want 1.0", v.d)
+	}
+	if v, ok := doc.lookup("ismaster"); !ok || !v.b {
+		t.Fatalf("reply ismaster = %v, want true", v.b)
+	}
+}
+
+// TestBuildOpReplyRoundTrip does the same for the legacy OP_REPLY framing used to answer
+// OP_QUERY isMaster.
+func TestBuildOpReplyRoundTrip(t *testing.T) {
+	var b bsonBuilder
+	b.addBool("ismaster", true)
+	b.addDouble("ok", 1.0)
+	body := b.build()
+
+	msg := buildOpReply(12, 7, body)
+
+	if int(binary.LittleEndian.Uint32(msg[0:4])) != len(msg) {
+		t.Fatalf("messageLength mismatch")
+	}
+	h, err := parseHeader(msg[:16])
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if h.opCode != opReply {
+		t.Fatalf("opCode = %d, want OP_REPLY", h.opCode)
+	}
+	if h.responseTo != 7 {
+		t.Fatalf("responseTo = %d, want 7", h.responseTo)
+	}
+
+	// OP_REPLY body starts after: responseFlags(4) + cursorID(8) + startingFrom(4) + numberReturned(4) = 20 bytes.
+	doc, err := decodeDocument(msg[16+20:])
+	if err != nil {
+		t.Fatalf("decode OP_REPLY body: %v", err)
+	}
+	if v, ok := doc.lookup("ok"); !ok || v.d != 1.0 {
+		t.Fatalf("OP_REPLY ok = %v, want 1.0", v.d)
+	}
+}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -257,6 +257,46 @@ func SaveJenkinsRequest(in *proto.JenkinsRequest) error {
 	return err
 }
 
+func SaveMongoConnect(in *proto.MongoConnectRequest) error {
+	if honeypotClient == nil {
+		return nil
+	}
+	ctx := context.Background()
+	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
+	_, err := honeypotClient.SaveMongoConnect(ctx, in)
+	return err
+}
+
+func SaveMongoCommand(in *proto.MongoCommandRequest) error {
+	if honeypotClient == nil {
+		return nil
+	}
+	ctx := context.Background()
+	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
+	_, err := honeypotClient.SaveMongoCommand(ctx, in)
+	return err
+}
+
+func SaveMemcachedConnect(in *proto.MemcachedConnectRequest) error {
+	if honeypotClient == nil {
+		return nil
+	}
+	ctx := context.Background()
+	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
+	_, err := honeypotClient.SaveMemcachedConnect(ctx, in)
+	return err
+}
+
+func SaveMemcachedCommand(in *proto.MemcachedCommandRequest) error {
+	if honeypotClient == nil {
+		return nil
+	}
+	ctx := context.Background()
+	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
+	_, err := honeypotClient.SaveMemcachedCommand(ctx, in)
+	return err
+}
+
 func GetCommandResponse(in *proto.CommandRequest) (*proto.CommandResponse, error) {
 	// Guard against an uninitialized client (e.g. before Connect, or in unit tests) so
 	// callers get a clean error and fall back to their local behavior instead of panicking.

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -24,6 +24,11 @@ var (
 	conn           *grpc.ClientConn
 	connMetadata   = metadata.New(map[string]string{"authorization": os.Getenv("API_KEY")})
 	honeypotClient proto.HoneypotClient
+
+	// saveTimeout bounds the newer honeypots' persistence calls (mongo/memcached) so a
+	// stalled gRPC server can't let fire-and-forget calls block forever and accumulate.
+	// A package var so tests can shrink it.
+	saveTimeout = 5 * time.Second
 )
 
 func Setup() error {
@@ -261,7 +266,8 @@ func SaveMongoConnect(in *proto.MongoConnectRequest) error {
 	if honeypotClient == nil {
 		return nil
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), saveTimeout)
+	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
 	_, err := honeypotClient.SaveMongoConnect(ctx, in)
 	return err
@@ -271,7 +277,8 @@ func SaveMongoCommand(in *proto.MongoCommandRequest) error {
 	if honeypotClient == nil {
 		return nil
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), saveTimeout)
+	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
 	_, err := honeypotClient.SaveMongoCommand(ctx, in)
 	return err
@@ -281,7 +288,8 @@ func SaveMemcachedConnect(in *proto.MemcachedConnectRequest) error {
 	if honeypotClient == nil {
 		return nil
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), saveTimeout)
+	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
 	_, err := honeypotClient.SaveMemcachedConnect(ctx, in)
 	return err
@@ -291,7 +299,8 @@ func SaveMemcachedCommand(in *proto.MemcachedCommandRequest) error {
 	if honeypotClient == nil {
 		return nil
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), saveTimeout)
+	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
 	_, err := honeypotClient.SaveMemcachedCommand(ctx, in)
 	return err

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -1,0 +1,63 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"google.golang.org/grpc"
+)
+
+// blockingClient stands in for a stalled gRPC server: the calls the honeypots make block
+// until their context is cancelled. Every other method is inherited (and unused) from the
+// embedded nil interface.
+type blockingClient struct {
+	proto.HoneypotClient
+}
+
+func (blockingClient) SaveMemcachedConnect(ctx context.Context, in *proto.MemcachedConnectRequest, opts ...grpc.CallOption) (*proto.SaveReply, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingClient) SaveMemcachedCommand(ctx context.Context, in *proto.MemcachedCommandRequest, opts ...grpc.CallOption) (*proto.SaveReply, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestSaveMemcachedIsTimeBounded is the regression for finding 5: a fire-and-forget
+// persistence call against a stalled server must return within the bounded timeout
+// instead of blocking forever and letting goroutines/calls accumulate.
+func TestSaveMemcachedIsTimeBounded(t *testing.T) {
+	origClient, origTimeout := honeypotClient, saveTimeout
+	t.Cleanup(func() { honeypotClient, saveTimeout = origClient, origTimeout })
+	honeypotClient = blockingClient{}
+	saveTimeout = 100 * time.Millisecond
+
+	for _, tc := range []struct {
+		name string
+		call func() error
+	}{
+		{"connect", func() error { return SaveMemcachedConnect(&proto.MemcachedConnectRequest{}) }},
+		{"command", func() error { return SaveMemcachedCommand(&proto.MemcachedCommandRequest{}) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan error, 1)
+			start := time.Now()
+			go func() { done <- tc.call() }()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("expected a deadline error from the stalled server, got nil")
+				}
+				if elapsed := time.Since(start); elapsed > 2*time.Second {
+					t.Fatalf("call took %v, want bounded near saveTimeout", elapsed)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("call did not return; persistence is not time-bounded")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The server already fully supports the `mongodb` and `memcached` attack types (gRPC handlers, dashboard, API), but the agent only had orphaned proto stubs — no listeners, no persistence wrappers, no registration — so neither honeypot ever ran in production. This PR makes them real.

## memcached (TCP :11211, `MEMCACHED_HONEYPOT_PORT`)
- Text protocol: `version`, `stats` / `stats items` / `stats slabs`, `get` / `gets`, storage verbs `set/add/replace/append/prepend/cas` (with correct data-block draining so payloads aren't parsed as commands), `delete`, `flush_all`, `quit`, and unknown → `ERROR\r\n`.
- Server-driven responses via `cmdresp.LookupAndRecord("memcached", ...)`; falls back to hardcoded realistic defaults on a miss/unreachable server.
- Persists `SaveMemcachedConnect` (Protocol=`ascii`) + every command line via `SaveMemcachedCommand`.
- A few enticing fake keys for `get`; oversized item writes are refused with `SERVER_ERROR`.

## mongo (TCP :27017, `MONGO_HONEYPOT_PORT`)
- Wire protocol: header parse (length-bounded), `OP_QUERY` (legacy `isMaster` on `admin.$cmd`) and `OP_MSG` (modern `hello`/commands, including kind-1 document-sequence skipping).
- Plausible BSON server description: `ismaster`/`isWritablePrimary`/`helloOk` true, `maxWireVersion` 21, `maxBsonObjectSize`, `maxMessageSizeBytes`, `localTime`, fake `version` 7.0.5, `ok:1.0`. `buildInfo` returns a version doc.
- Captures auth attempts: SCRAM username (client-first message), SASL `PLAIN` username+password, legacy `authenticate` user; driver version from `hello` client metadata → `ClientVersion`. Auth is answered with a realistic AuthenticationFailed after capture.
- Minimal hand-rolled BSON codec — **no new go.mod dependency**.
- Persists `SaveMongoConnect` + `SaveMongoCommand`.

## Plumbing
- Added `SaveMongoConnect`, `SaveMongoCommand`, `SaveMemcachedConnect`, `SaveMemcachedCommand` to `persistence` — nil-client-safe (best-effort, matching `smtp`) so the listeners run without a live gRPC server.
- Registered both honeypots in `main.go`.

## Tests (TDD)
- Table-driven unit tests: memcached command parsing + response selection; mongo BSON encode/decode round-trip (+ exact-bytes pin) and wire header/OP_MSG/OP_QUERY framing.
- In-process integration tests per honeypot on an ephemeral port with persistence seams stubbed: memcached `version`→`VERSION `, `get foo`→`END`, storage data-block handling; mongo `OP_MSG hello` and `OP_QUERY isMaster` return well-formed BSON with `ok:1`/`ismaster:true`, and a PLAIN saslStart is captured.
- `go build ./...`, `make build`, `go vet`, `gofmt` all clean; full suite green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)