### PR TITLE
feat: make elasticsearch + kubernetes honeypot ports overridable

### DIFF
--- a/elasticsearch/es.go
+++ b/elasticsearch/es.go
@@ -18,6 +18,8 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+const defaultPort = "9200"
+
 const resp = `{
   "name": "Y6xYwin",
   "cluster_name": "elasticsearch",
@@ -95,6 +97,15 @@ func (h *honeypot) Name() string {
 	return "elasticsearch"
 }
 
+func resolvePort() string {
+	port := os.Getenv("ELASTICSEARCH_HONEYPOT_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+	return port
+}
+
 func (h *honeypot) Start() {
-	h.logger.Fatal().Err(http.ListenAndServe(":9200", &ES{logger: h.logger})).Msg("failed to start")
+	port := resolvePort()
+	h.logger.Fatal().Err(http.ListenAndServe(":"+port, &ES{logger: h.logger})).Msg("failed to start")
 }

--- a/elasticsearch/es_test.go
+++ b/elasticsearch/es_test.go
@@ -10,6 +10,20 @@ import (
 	"github.com/joshrendek/threat.gg-agent/proto"
 )
 
+func TestResolvePortDefault(t *testing.T) {
+	if port := resolvePort(); port != defaultPort {
+		t.Fatalf("expected default port %q, got %q", defaultPort, port)
+	}
+}
+
+func TestResolvePortOverride(t *testing.T) {
+	t.Setenv("ELASTICSEARCH_HONEYPOT_PORT", "19200")
+
+	if port := resolvePort(); port != "19200" {
+		t.Fatalf("expected overridden port %q, got %q", "19200", port)
+	}
+}
+
 func TestServeHTTPPersistsMethodAndPathBeforeOverride(t *testing.T) {
 	originalSave := saveElasticRequest
 	originalLookup := cmdresp.GetCommandResponse

--- a/kubernetes/k8s.go
+++ b/kubernetes/k8s.go
@@ -18,6 +18,8 @@ import (
   "time"
 )
 
+const defaultPort = "6443"
+
 var _ honeypots.Honeypot = &honeypot{}
 
 type honeypot struct {
@@ -33,7 +35,16 @@ func (h *honeypot) Name() string {
 	return "kubernetes"
 }
 
+func resolvePort() string {
+	port := os.Getenv("KUBERNETES_HONEYPOT_PORT")
+	if port == "" {
+		port = defaultPort
+	}
+	return port
+}
+
 func (h *honeypot) Start() {
+	port := resolvePort()
 	fmt.Println("----------- START K8s")
 	router := mux.NewRouter()
 	router.Use(h.LoggingMiddleware)
@@ -93,13 +104,13 @@ func (h *honeypot) Start() {
 
 	// Create a custom server to use TLS
 	server := &http.Server{
-		Addr:      ":6443",
+		Addr:      ":" + port,
 		Handler:   router,
 		TLSConfig: tlsConfig,
 	}
 
 	// Start the server
-	fmt.Println("Starting mock Kubernetes API server on :6443")
+	fmt.Println("Starting mock Kubernetes API server on :" + port)
 	h.logger.Fatal().Err(server.ListenAndServeTLS("", "")).Msg("failed to start k8s")
 }
 

--- a/kubernetes/k8s_test.go
+++ b/kubernetes/k8s_test.go
@@ -1,0 +1,17 @@
+package kubernetes
+
+import "testing"
+
+func TestResolvePortDefault(t *testing.T) {
+	if port := resolvePort(); port != defaultPort {
+		t.Fatalf("expected default port %q, got %q", defaultPort, port)
+	}
+}
+
+func TestResolvePortOverride(t *testing.T) {
+	t.Setenv("KUBERNETES_HONEYPOT_PORT", "16443")
+
+	if port := resolvePort(); port != "16443" {
+		t.Fatalf("expected overridden port %q, got %q", "16443", port)
+	}
+}


### PR DESCRIPTION
Both honeypots hardcoded their listen port with no env var, unlike every
other honeypot (jenkins, docker, redis, telnet, ...), which blocked the
launch UI from offering a custom-port field for them.

- elasticsearch: reads ELASTICSEARCH_HONEYPOT_PORT, defaults to 9200
- kubernetes: reads KUBERNETES_HONEYPOT_PORT, defaults to 6443

Port resolution is extracted into a resolvePort() helper per package so it
can be unit tested without binding a socket.
