### PR TITLE
feat(agent): drop non-LLM scan noise from LLM honeypot capture

### DIFF
--- a/llmcore/filter.go
+++ b/llmcore/filter.go
@@ -1,0 +1,49 @@
+package llmcore
+
+import "strings"
+
+// apiSignalSegments is the set of second path segments under /api/ that belong to a real LLM
+// serving API (Ollama's model/inference verbs, Ray's dashboard job/cluster endpoints). This
+// keeps /api/tags, /api/generate, /api/jobs/… while rejecting generic /api/route, /api noise.
+var apiSignalSegments = map[string]bool{
+	"tags": true, "generate": true, "chat": true, "version": true, "ps": true,
+	"show": true, "pull": true, "push": true, "create": true, "copy": true,
+	"delete": true, "embeddings": true, "embed": true, "blobs": true,
+	"jobs": true, "cluster_status": true, "serve": true, "packages": true,
+	"actors": true, "nodes": true,
+}
+
+// exactSignalPaths are product-native LLM endpoints outside the /v1/ and /api/ families
+// (llama.cpp /props /completion /slots, vLLM /health /metrics, ComfyUI /system_stats /prompt,
+// LocalAI /models /readyz, Ray /nodes, …).
+var exactSignalPaths = map[string]bool{
+	"/models": true, "/props": true, "/health": true, "/readyz": true,
+	"/metrics": true, "/version": true, "/slots": true, "/completion": true,
+	"/completions": true, "/tokenize": true, "/detokenize": true,
+	"/embedding": true, "/infill": true, "/system_stats": true,
+	"/object_info": true, "/queue": true, "/history": true, "/prompt": true,
+	"/nodes": true, "/interrupt": true,
+}
+
+// isSignalPath reports whether a request path targets a real LLM API surface — the OpenAI
+// family (/v1/*), the Ollama/Ray /api/<verb> verbs, or a product-native endpoint. Everything
+// else is generic internet scanning (/, favicon, nmap, proxy CONNECT, HTTP/2 PRI, Next.js RSC
+// exploits, LFI probes, router CVEs) that the honeypot should still answer convincingly but
+// must not persist — it drowns the real LLM-attack signal otherwise.
+func isSignalPath(path string) bool {
+	p := strings.ToLower(strings.TrimRight(path, "/"))
+	if p == "" {
+		return false
+	}
+	if strings.HasPrefix(p, "/v1/") {
+		return true
+	}
+	if strings.HasPrefix(p, "/api/") {
+		seg := p[len("/api/"):]
+		if i := strings.IndexByte(seg, '/'); i >= 0 {
+			seg = seg[:i]
+		}
+		return apiSignalSegments[seg]
+	}
+	return exactSignalPaths[p]
+}

--- a/llmcore/filter_test.go
+++ b/llmcore/filter_test.go
@@ -1,0 +1,90 @@
+package llmcore
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+func TestIsSignalPath(t *testing.T) {
+	signal := []string{
+		"/v1/models", "/v1/chat/completions", "/v1/completions", "/v1/embeddings",
+		"/v1/responses", // new OpenAI Responses API — caught by the /v1/ rule
+		"/api/tags", "/api/generate", "/api/chat", "/api/version", "/api/ps",
+		"/api/show", "/api/pull", "/api/embeddings", "/api/jobs/", "/api/jobs/raysubmit_x",
+		"/api/cluster_status", "/models", "/props", "/health", "/readyz", "/metrics",
+		"/completion", "/tokenize", "/system_stats", "/object_info", "/queue", "/prompt",
+		"/nodes", "/v1/models/", // trailing slash tolerated
+	}
+	for _, p := range signal {
+		if !isSignalPath(p) {
+			t.Errorf("isSignalPath(%q) = false, want true (signal)", p)
+		}
+	}
+	noise := []string{
+		"", "/", "/favicon.ico", "/SDK/webLanguage", "/login", "/robots.txt", "/sitemap.xml",
+		"/nice ports,/Trinity.txt.bak", "*", "/mcp", "/sse", "/api", "/app", "/_next",
+		"/_next/server", "/api/route", "/../../../../etc/passwd", "/HNAP1", "/webui",
+		"/.well-known/security.txt", "/evox/about", "/sdk",
+	}
+	for _, p := range noise {
+		if isSignalPath(p) {
+			t.Errorf("isSignalPath(%q) = true, want false (noise)", p)
+		}
+	}
+}
+
+func TestCaptureDropsNoiseSavesSignal(t *testing.T) {
+	call := func(method, path, body string) (saved bool, servedNext bool) {
+		got := make(chan *proto.LlmRequest, 1)
+		save := func(in *proto.LlmRequest) error { got <- in; return nil }
+		nextCalled := false
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { nextCalled = true; w.WriteHeader(200) })
+		var rdr *strings.Reader
+		if body != "" {
+			rdr = strings.NewReader(body)
+		}
+		var req *http.Request
+		if rdr != nil {
+			req = httptest.NewRequest(method, path, rdr)
+		} else {
+			req = httptest.NewRequest(method, path, nil)
+		}
+		Capture(save)(next).ServeHTTP(httptest.NewRecorder(), req)
+		select {
+		case <-got:
+			return true, nextCalled
+		case <-time.After(150 * time.Millisecond):
+			return false, nextCalled
+		}
+	}
+
+	// Noise: NOT persisted, but the honeypot still responds (next called).
+	for _, tc := range []struct{ m, p string }{
+		{"GET", "/"}, {"GET", "/favicon.ico"}, {"POST", "/api/route"}, {"GET", "/HNAP1"},
+	} {
+		saved, served := call(tc.m, tc.p, "")
+		if saved {
+			t.Errorf("%s %s: was persisted, want dropped as noise", tc.m, tc.p)
+		}
+		if !served {
+			t.Errorf("%s %s: downstream handler not called (honeypot must still respond)", tc.m, tc.p)
+		}
+	}
+
+	// Signal: persisted.
+	saved, served := call("POST", "/v1/chat/completions", `{"model":"x","messages":[]}`)
+	if !saved {
+		t.Error("POST /v1/chat/completions: not persisted, want captured (signal)")
+	}
+	if !served {
+		t.Error("signal request: downstream not called")
+	}
+	if saved, _ := call("GET", "/api/tags", ""); !saved {
+		t.Error("GET /api/tags: not persisted, want captured (signal)")
+	}
+}

--- a/llmcore/llmcore.go
+++ b/llmcore/llmcore.go
@@ -49,6 +49,13 @@ func Capture(save func(*proto.LlmRequest) error) func(http.Handler) http.Handler
 }
 
 func captureAndSave(r *http.Request, save func(*proto.LlmRequest) error) {
+	// Only persist requests that touch a real LLM API surface. Generic internet scanning
+	// (favicon, nmap, proxy CONNECT, Next.js exploits, LFI probes) still gets a response from
+	// the honeypot's handlers, but is not stored — it otherwise drowns the real LLM signal.
+	if !isSignalPath(r.URL.Path) {
+		return
+	}
+
 	guid := uuid.NewV4()
 
 	var body string


### PR DESCRIPTION
## Summary
The six LLM honeypots sit on ports (8000/808x/8188/8265/11434) that draw heavy generic internet scanning. From prod capture, **~95% of stored rows were noise** — `GET /` (794), favicon, `/SDK/webLanguage`, proxy `CONNECT`, nmap `/nice ports…`, HTTP/2 `PRI *`, Next.js RSC exploits (`/api/route`, `/_next`), LFI (`/../../etc/passwd`), router CVEs (`/HNAP1`) — drowning the real LLM signal.

`captureAndSave` now persists only requests to a **real LLM API surface**: OpenAI `/v1/*`, Ollama/Ray `/api/<verb>` (tags/generate/chat/version/ps/show/pull/jobs/cluster_status/…), and product-native exact paths (`/models`, `/props`, `/completion`, `/system_stats`, `/object_info`, `/prompt`, `/health`, `/metrics`, `/readyz`, …). Everything else still gets a convincing response from the honeypot handlers — it just isn't stored.

Mirrors the prod cleanup that deleted the ~2,800 existing noise rows across the six types (kept the 139 genuine LLM interactions).

## Tests
`isSignalPath` table (signal vs noise, incl. `/v1/responses` caught by the `/v1/` rule and `/api/route`/`/mcp` rejected); `Capture` drops noise but still serves it, and persists signal. Full `llmcore` + all six honeypot suites green; `go vet` clean; arm/386 cross-compiles clean.

## Note
`POST /mcp` + `GET /sse` (MCP-server hunting) are treated as noise here — LLM-adjacent but not emulated by these honeypots. Could justify a dedicated MCP honeypot later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)