### PR TITLE
feat(llm): eliminate honeypot fingerprints across the LLM surface (PRD 033)

### DIFF
--- a/llamacpp/llamacpp.go
+++ b/llamacpp/llamacpp.go
@@ -41,6 +41,9 @@ func (h *honeypot) Start() {
 	h.logger.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%s", port), handler)).Msg("failed to start")
 }
 
+// profile: llama.cpp's server is cpp-httplib, which appends "; charset=utf-8" to JSON.
+var profile = llmcore.Profile{DefaultModel: defaultModel, ContentType: llmcore.CTJSONCharset}
+
 func newRouter() http.Handler {
 	r := mux.NewRouter()
 	r.HandleFunc("/props", handleProps).Methods("GET")
@@ -49,7 +52,7 @@ func newRouter() http.Handler {
 	}).Methods("GET")
 	r.HandleFunc("/v1/models", handleModels).Methods("GET")
 	r.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.ChatCompletion(w, req, defaultModel)
+		llmcore.ChatCompletion(w, req, profile)
 	}).Methods("POST")
 	r.HandleFunc("/completion", handleCompletion).Methods("POST")
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -10,15 +10,14 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	uuid "github.com/satori/go.uuid"
 )
 
-// Model is one entry in an OpenAI /v1/models or Ollama catalog listing.
+// Model is one entry in an OpenAI /v1/models listing.
 type Model struct {
-	ID      string
-	Created int64
-	OwnedBy string
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	OwnedBy string `json:"owned_by"`
 }
 
 // replyPool holds benign, plausible assistant completions. They look like a real model
@@ -119,6 +118,13 @@ func estTokens(s string) int {
 	return n
 }
 
+// chatTemplateTokens approximates the system prompt and chat-template scaffolding a real server
+// prepends before the user's text. Real Ollama reports prompt_eval_count ~30 for a one-word
+// prompt, so reporting only the user's own token count is conspicuously low.
+const chatTemplateTokens = 28
+
+func promptTokensFor(text string) int { return chatTemplateTokens + estTokens(text) }
+
 func wantsStream(body []byte, defaultStream bool) bool {
 	var m struct {
 		Stream *bool `json:"stream"`
@@ -129,9 +135,45 @@ func wantsStream(body []byte, defaultStream bool) bool {
 	return *m.Stream
 }
 
+// maxTokensOf reads the generation cap under any of the names these surfaces accept: OpenAI's
+// max_tokens and max_completion_tokens, the Responses API's max_output_tokens, and Ollama's
+// options.num_predict. Returns 0 when uncapped.
+func maxTokensOf(body []byte) int {
+	var m struct {
+		MaxTokens           *int `json:"max_tokens"`
+		MaxCompletionTokens *int `json:"max_completion_tokens"`
+		MaxOutputTokens     *int `json:"max_output_tokens"`
+		Options             struct {
+			NumPredict *int `json:"num_predict"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil {
+		return 0
+	}
+	for _, v := range []*int{m.MaxTokens, m.MaxCompletionTokens, m.MaxOutputTokens, m.Options.NumPredict} {
+		if v != nil && *v > 0 {
+			return *v
+		}
+	}
+	return 0
+}
+
+// capReply truncates reply to at most max generated tokens and reports the finish reason a real
+// server would return. Hitting the cap yields "length", not "stop" — scanners routinely send
+// max_tokens=1 and read the finish reason back, so always reporting "stop" is a giveaway.
+func capReply(reply string, max int) (text string, chunks []string, finish string) {
+	chunks = splitWords(reply)
+	if max > 0 && len(chunks) >= max {
+		chunks = chunks[:max]
+		return strings.TrimRight(strings.Join(chunks, ""), " "), chunks, "length"
+	}
+	return reply, chunks, "stop"
+}
+
 func promptText(body []byte) string {
 	var m struct {
 		Prompt   string `json:"prompt"`
+		Input    string `json:"input"`
 		Messages []struct {
 			Content string `json:"content"`
 		} `json:"messages"`
@@ -139,6 +181,9 @@ func promptText(body []byte) string {
 	_ = json.Unmarshal(body, &m)
 	if m.Prompt != "" {
 		return m.Prompt
+	}
+	if m.Input != "" {
+		return m.Input
 	}
 	if len(m.Messages) > 0 {
 		return m.Messages[len(m.Messages)-1].Content
@@ -161,36 +206,137 @@ func modelOr(body []byte, def string) string {
 	return def
 }
 
+// ValidJSONBody reports whether body parses as a JSON object, along with the parse error a real
+// server would echo when it does not. Real servers 400 on malformed input; happily returning a
+// completion for "not-json" is a tell.
+func ValidJSONBody(body []byte) (string, bool) {
+	if len(strings.TrimSpace(string(body))) == 0 {
+		return "", true
+	}
+	var v map[string]any
+	if err := json.Unmarshal(body, &v); err != nil {
+		return err.Error(), false
+	}
+	return "", true
+}
+
+func completionID(p Profile, prefix string) string {
+	if p.ShortIDs {
+		// Ollama's OpenAI layer emits a short numeric suffix, e.g. chatcmpl-964.
+		return fmt.Sprintf("%s-%d", prefix, rand.Intn(1000))
+	}
+	return fmt.Sprintf("%s-%016x%016x", prefix, rand.Uint64(), rand.Uint64())
+}
+
+// -- OpenAI-shaped payloads. Field order mirrors the real servers' struct order; building these
+// from map[string]any would sort the keys alphabetically, which no real implementation does.
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type openAIChatChoice struct {
+	Index        int         `json:"index"`
+	Message      chatMessage `json:"message"`
+	FinishReason string      `json:"finish_reason"`
+}
+
+type openAIChatResponse struct {
+	ID                string             `json:"id"`
+	Object            string             `json:"object"`
+	Created           int64              `json:"created"`
+	Model             string             `json:"model"`
+	SystemFingerprint string             `json:"system_fingerprint,omitempty"`
+	Choices           []openAIChatChoice `json:"choices"`
+	Usage             openAIUsage        `json:"usage"`
+}
+
+type openAIDelta struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChunkChoice struct {
+	Index        int         `json:"index"`
+	Delta        openAIDelta `json:"delta"`
+	FinishReason *string     `json:"finish_reason"`
+}
+
+type openAIChatChunk struct {
+	ID                string              `json:"id"`
+	Object            string              `json:"object"`
+	Created           int64               `json:"created"`
+	Model             string              `json:"model"`
+	SystemFingerprint string              `json:"system_fingerprint,omitempty"`
+	Choices           []openAIChunkChoice `json:"choices"`
+}
+
+type openAITextChoice struct {
+	Text         string `json:"text"`
+	Index        int    `json:"index"`
+	Logprobs     *int   `json:"logprobs"`
+	FinishReason string `json:"finish_reason"`
+}
+
+type openAITextResponse struct {
+	ID                string             `json:"id"`
+	Object            string             `json:"object"`
+	Created           int64              `json:"created"`
+	Model             string             `json:"model"`
+	SystemFingerprint string             `json:"system_fingerprint,omitempty"`
+	Choices           []openAITextChoice `json:"choices"`
+	Usage             openAIUsage        `json:"usage"`
+}
+
 // ChatCompletion writes an OpenAI /v1/chat/completions response, streaming SSE chunks
 // when the request asks for "stream":true (default false for chat).
-func ChatCompletion(w http.ResponseWriter, r *http.Request, defaultModel string) {
+func ChatCompletion(w http.ResponseWriter, r *http.Request, p Profile) {
 	body := readBody(r)
-	model := modelOr(body, defaultModel)
-	reply := smartReply(promptText(body))
-	id := "chatcmpl-" + uuid.NewV4().String()
+	if msg, ok := ValidJSONBody(body); !ok {
+		WriteOpenAIError(w, p, http.StatusBadRequest, msg, "invalid_request_error")
+		return
+	}
+	model, known := p.resolveModel(body)
+	if !known {
+		WriteModelNotFoundV1(w, p, model)
+		return
+	}
+	reply, chunks, finish := capReply(smartReply(promptText(body)), maxTokensOf(body))
+	id := completionID(p, "chatcmpl")
 	created := time.Now().Unix()
 
 	if wantsStream(body, false) {
-		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Content-Type", CTEventStream)
 		w.Header().Set("Cache-Control", "no-cache")
 		w.WriteHeader(http.StatusOK)
 		flusher, _ := w.(http.Flusher)
-		writeChunk := func(delta map[string]any, finish any) {
-			chunk := map[string]any{
-				"id": id, "object": "chat.completion.chunk", "created": created, "model": model,
-				"choices": []map[string]any{{"index": 0, "delta": delta, "finish_reason": finish}},
-			}
-			b, _ := json.Marshal(chunk)
+		emit := func(content string, finish *string) {
+			b, _ := json.Marshal(openAIChatChunk{
+				ID: id, Object: "chat.completion.chunk", Created: created, Model: model,
+				SystemFingerprint: p.SystemFingerprint,
+				Choices: []openAIChunkChoice{{
+					Index: 0,
+					Delta: openAIDelta{Role: "assistant", Content: content},
+					// finish_reason is explicitly null until the terminal chunk.
+					FinishReason: finish,
+				}},
+			})
 			fmt.Fprintf(w, "data: %s\n\n", b)
 			if flusher != nil {
 				flusher.Flush()
 			}
 		}
-		writeChunk(map[string]any{"role": "assistant"}, nil)
-		for _, word := range splitWords(reply) {
-			writeChunk(map[string]any{"content": word}, nil)
+		for _, c := range chunks {
+			emit(c, nil)
 		}
-		writeChunk(map[string]any{}, "stop")
+		emit("", &finish)
 		fmt.Fprint(w, "data: [DONE]\n\n")
 		if flusher != nil {
 			flusher.Flush()
@@ -198,116 +344,217 @@ func ChatCompletion(w http.ResponseWriter, r *http.Request, defaultModel string)
 		return
 	}
 
-	pt := estTokens(promptText(body))
-	ct := estTokens(reply)
-	WriteJSON(w, http.StatusOK, map[string]any{
-		"id": id, "object": "chat.completion", "created": created, "model": model,
-		"choices": []map[string]any{{
-			"index":         0,
-			"message":       map[string]any{"role": "assistant", "content": reply},
-			"finish_reason": "stop",
+	pt := promptTokensFor(promptText(body))
+	WriteJSONCT(w, http.StatusOK, CTJSON, openAIChatResponse{
+		ID: id, Object: "chat.completion", Created: created, Model: model,
+		SystemFingerprint: p.SystemFingerprint,
+		Choices: []openAIChatChoice{{
+			Index:        0,
+			Message:      chatMessage{Role: "assistant", Content: reply},
+			FinishReason: finish,
 		}},
-		"usage": map[string]any{"prompt_tokens": pt, "completion_tokens": ct, "total_tokens": pt + ct},
+		Usage: openAIUsage{PromptTokens: pt, CompletionTokens: len(chunks), TotalTokens: pt + len(chunks)},
 	})
 }
 
 // Completion writes an OpenAI /v1/completions (legacy text completion) response.
-func Completion(w http.ResponseWriter, r *http.Request, defaultModel string) {
+func Completion(w http.ResponseWriter, r *http.Request, p Profile) {
 	body := readBody(r)
-	model := modelOr(body, defaultModel)
-	reply := smartReply(promptText(body))
-	pt := estTokens(promptText(body))
-	ct := estTokens(reply)
-	WriteJSON(w, http.StatusOK, map[string]any{
-		"id": "cmpl-" + uuid.NewV4().String(), "object": "text_completion",
-		"created": time.Now().Unix(), "model": model,
-		"choices": []map[string]any{{
-			"text": reply, "index": 0, "logprobs": nil, "finish_reason": "stop",
+	if msg, ok := ValidJSONBody(body); !ok {
+		WriteOpenAIError(w, p, http.StatusBadRequest, msg, "invalid_request_error")
+		return
+	}
+	model, known := p.resolveModel(body)
+	if !known {
+		WriteModelNotFoundV1(w, p, model)
+		return
+	}
+	reply, chunks, finish := capReply(smartReply(promptText(body)), maxTokensOf(body))
+	pt := promptTokensFor(promptText(body))
+	WriteJSONCT(w, http.StatusOK, CTJSON, openAITextResponse{
+		ID: completionID(p, "cmpl"), Object: "text_completion",
+		Created: time.Now().Unix(), Model: model,
+		SystemFingerprint: p.SystemFingerprint,
+		Choices: []openAITextChoice{{
+			Text: reply, Index: 0, Logprobs: nil, FinishReason: finish,
 		}},
-		"usage": map[string]any{"prompt_tokens": pt, "completion_tokens": ct, "total_tokens": pt + ct},
+		Usage: openAIUsage{PromptTokens: pt, CompletionTokens: len(chunks), TotalTokens: pt + len(chunks)},
 	})
+}
+
+// -- Ollama-native /api payloads.
+
+type ollamaGenerateChunk struct {
+	Model     string `json:"model"`
+	CreatedAt string `json:"created_at"`
+	Response  string `json:"response"`
+	Done      bool   `json:"done"`
+}
+
+type ollamaGenerateFinal struct {
+	Model              string `json:"model"`
+	CreatedAt          string `json:"created_at"`
+	Response           string `json:"response"`
+	Done               bool   `json:"done"`
+	DoneReason         string `json:"done_reason"`
+	Context            []int  `json:"context,omitempty"`
+	TotalDuration      int64  `json:"total_duration"`
+	LoadDuration       int64  `json:"load_duration"`
+	PromptEvalCount    int    `json:"prompt_eval_count"`
+	PromptEvalDuration int64  `json:"prompt_eval_duration"`
+	EvalCount          int    `json:"eval_count"`
+	EvalDuration       int64  `json:"eval_duration"`
+}
+
+type ollamaChatChunk struct {
+	Model     string      `json:"model"`
+	CreatedAt string      `json:"created_at"`
+	Message   chatMessage `json:"message"`
+	Done      bool        `json:"done"`
+}
+
+type ollamaChatFinal struct {
+	Model              string      `json:"model"`
+	CreatedAt          string      `json:"created_at"`
+	Message            chatMessage `json:"message"`
+	Done               bool        `json:"done"`
+	DoneReason         string      `json:"done_reason"`
+	TotalDuration      int64       `json:"total_duration"`
+	LoadDuration       int64       `json:"load_duration"`
+	PromptEvalCount    int         `json:"prompt_eval_count"`
+	PromptEvalDuration int64       `json:"prompt_eval_duration"`
+	EvalCount          int         `json:"eval_count"`
+	EvalDuration       int64       `json:"eval_duration"`
+}
+
+// nowNano formats a timestamp the way Ollama does: RFC3339 with nanosecond precision. Each
+// streamed chunk gets a fresh one, so timestamps advance across a stream instead of every
+// chunk repeating the value computed when the handler started.
+func nowNano() string { return time.Now().UTC().Format(time.RFC3339Nano) }
+
+// fakeContext synthesises the token-id array Ollama returns from /api/generate. Real ids are
+// vocabulary indices bracketed by high-numbered special tokens; omitting the field entirely is
+// what gives a fake away, not the specific ids.
+func fakeContext(n int) []int {
+	if n < 1 {
+		n = 1
+	}
+	if n > 512 {
+		n = 512
+	}
+	out := make([]int, 0, n+6)
+	out = append(out, 151644, 8948, 198) // <|im_start|> system \n
+	for i := 0; i < n; i++ {
+		out = append(out, 1000+rand.Intn(126000))
+	}
+	out = append(out, 151645, 198, 151643) // <|im_end|> \n <|endoftext|>
+	return out
+}
+
+// ndjsonWriter returns a helper that marshals and flushes one NDJSON line per call.
+func ndjsonWriter(w http.ResponseWriter) func(any) {
+	flusher, _ := w.(http.Flusher)
+	return func(v any) {
+		b, _ := json.Marshal(v)
+		fmt.Fprintf(w, "%s\n", b)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
 }
 
 // OllamaGenerate writes an Ollama /api/generate response. Ollama streams NDJSON by
 // default (one JSON object per line), ending with a done:true summary line; "stream":false
 // collapses to a single object.
-func OllamaGenerate(w http.ResponseWriter, r *http.Request, defaultModel string) {
+func OllamaGenerate(w http.ResponseWriter, r *http.Request, p Profile) {
 	body := readBody(r)
-	model := modelOr(body, defaultModel)
-	reply := smartReply(promptText(body))
-	created := time.Now().UTC().Format(time.RFC3339Nano)
-
-	if !wantsStream(body, true) {
-		WriteJSON(w, http.StatusOK, ollamaFinal(model, created, reply))
+	if msg, ok := ValidJSONBody(body); !ok {
+		WriteOllamaError(w, p, http.StatusBadRequest, msg)
 		return
 	}
-	w.Header().Set("Content-Type", "application/x-ndjson")
-	w.WriteHeader(http.StatusOK)
-	flusher, _ := w.(http.Flusher)
-	enc := json.NewEncoder(w)
-	for _, word := range splitWords(reply) {
-		_ = enc.Encode(map[string]any{"model": model, "created_at": created, "response": word, "done": false})
-		if flusher != nil {
-			flusher.Flush()
+	model, known := p.resolveModel(body)
+	if !known {
+		WriteModelNotFoundAPI(w, p, model)
+		return
+	}
+	prompt := promptText(body)
+	reply, chunks, finish := capReply(smartReply(prompt), maxTokensOf(body))
+	pt := promptTokensFor(prompt)
+	t := newTimings(model, keepAliveOf(body), pt, len(chunks))
+
+	final := func(response string) ollamaGenerateFinal {
+		return ollamaGenerateFinal{
+			Model: model, CreatedAt: nowNano(), Response: response, Done: true,
+			DoneReason:         finish,
+			Context:            fakeContext(pt + len(chunks)),
+			TotalDuration:      t.Total.Nanoseconds(),
+			LoadDuration:       t.Load.Nanoseconds(),
+			PromptEvalCount:    pt,
+			PromptEvalDuration: t.PromptEval.Nanoseconds(),
+			EvalCount:          len(chunks),
+			EvalDuration:       t.Eval.Nanoseconds(),
 		}
 	}
-	_ = enc.Encode(ollamaFinal(model, created, ""))
-	if flusher != nil {
-		flusher.Flush()
+
+	if !wantsStream(body, true) {
+		WriteJSONCT(w, http.StatusOK, p.ct(), final(reply))
+		return
 	}
+	w.Header().Set("Content-Type", CTNDJSON)
+	w.WriteHeader(http.StatusOK)
+	writeLine := ndjsonWriter(w)
+	for _, c := range chunks {
+		writeLine(ollamaGenerateChunk{Model: model, CreatedAt: nowNano(), Response: c, Done: false})
+	}
+	writeLine(final(""))
 }
 
 // OllamaChat writes an Ollama /api/chat response (message-shaped, single object when
 // stream is false; NDJSON otherwise).
-func OllamaChat(w http.ResponseWriter, r *http.Request, defaultModel string) {
+func OllamaChat(w http.ResponseWriter, r *http.Request, p Profile) {
 	body := readBody(r)
-	model := modelOr(body, defaultModel)
-	reply := smartReply(promptText(body))
-	created := time.Now().UTC().Format(time.RFC3339Nano)
-	final := func(content string) map[string]any {
-		m := map[string]any{
-			"model": model, "created_at": created,
-			"message":           map[string]any{"role": "assistant", "content": content},
-			"done":              true,
-			"total_duration":    1234567890,
-			"eval_count":        estTokens(reply),
-			"prompt_eval_count": estTokens(promptText(body)),
-		}
-		return m
-	}
-	if !wantsStream(body, true) {
-		WriteJSON(w, http.StatusOK, final(reply))
+	if msg, ok := ValidJSONBody(body); !ok {
+		WriteOllamaError(w, p, http.StatusBadRequest, msg)
 		return
 	}
-	w.Header().Set("Content-Type", "application/x-ndjson")
-	w.WriteHeader(http.StatusOK)
-	flusher, _ := w.(http.Flusher)
-	enc := json.NewEncoder(w)
-	for _, word := range splitWords(reply) {
-		_ = enc.Encode(map[string]any{
-			"model": model, "created_at": created,
-			"message": map[string]any{"role": "assistant", "content": word}, "done": false,
-		})
-		if flusher != nil {
-			flusher.Flush()
+	model, known := p.resolveModel(body)
+	if !known {
+		WriteModelNotFoundAPI(w, p, model)
+		return
+	}
+	prompt := promptText(body)
+	reply, chunks, finish := capReply(smartReply(prompt), maxTokensOf(body))
+	pt := promptTokensFor(prompt)
+	t := newTimings(model, keepAliveOf(body), pt, len(chunks))
+
+	final := func(content string) ollamaChatFinal {
+		return ollamaChatFinal{
+			Model: model, CreatedAt: nowNano(),
+			Message: chatMessage{Role: "assistant", Content: content},
+			Done:    true, DoneReason: finish,
+			TotalDuration:      t.Total.Nanoseconds(),
+			LoadDuration:       t.Load.Nanoseconds(),
+			PromptEvalCount:    pt,
+			PromptEvalDuration: t.PromptEval.Nanoseconds(),
+			EvalCount:          len(chunks),
+			EvalDuration:       t.Eval.Nanoseconds(),
 		}
 	}
-	_ = enc.Encode(final(""))
-	if flusher != nil {
-		flusher.Flush()
-	}
-}
 
-func ollamaFinal(model, created, response string) map[string]any {
-	return map[string]any{
-		"model": model, "created_at": created, "response": response, "done": true,
-		"done_reason":       "stop",
-		"total_duration":    1234567890,
-		"load_duration":     123456,
-		"prompt_eval_count": 12,
-		"eval_count":        24,
-		"eval_duration":     987654,
+	if !wantsStream(body, true) {
+		WriteJSONCT(w, http.StatusOK, p.ct(), final(reply))
+		return
 	}
+	w.Header().Set("Content-Type", CTNDJSON)
+	w.WriteHeader(http.StatusOK)
+	writeLine := ndjsonWriter(w)
+	for _, c := range chunks {
+		writeLine(ollamaChatChunk{
+			Model: model, CreatedAt: nowNano(),
+			Message: chatMessage{Role: "assistant", Content: c}, Done: false,
+		})
+	}
+	writeLine(final(""))
 }
 
 // splitWords chunks s into space-preserving tokens for streaming.

--- a/llmcore/generate_test.go
+++ b/llmcore/generate_test.go
@@ -12,7 +12,7 @@ func TestChatCompletionNonStreamEchoesModelAndShape(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
 		strings.NewReader(`{"model":"mixtral","messages":[{"role":"user","content":"hi there"}]}`))
 	rec := httptest.NewRecorder()
-	ChatCompletion(rec, req, "gpt-3.5-turbo")
+	ChatCompletion(rec, req, Profile{DefaultModel: "gpt-3.5-turbo"})
 
 	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
 		t.Fatalf("content-type = %q", ct)
@@ -60,7 +60,7 @@ func TestChatCompletionStreamEmitsSSEChunksAndDone(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
 		strings.NewReader(`{"model":"llama3","stream":true,"messages":[{"role":"user","content":"hello"}]}`))
 	rec := httptest.NewRecorder()
-	ChatCompletion(rec, req, "gpt-3.5-turbo")
+	ChatCompletion(rec, req, Profile{DefaultModel: "gpt-3.5-turbo"})
 
 	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
 		t.Fatalf("content-type = %q, want text/event-stream", ct)
@@ -81,7 +81,7 @@ func TestOllamaGenerateNonStream(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/generate",
 		strings.NewReader(`{"model":"llama3.2","prompt":"why is the sky blue","stream":false}`))
 	rec := httptest.NewRecorder()
-	OllamaGenerate(rec, req, "llama3.2")
+	OllamaGenerate(rec, req, Profile{DefaultModel: "llama3.2"})
 	var resp struct {
 		Model    string `json:"model"`
 		Response string `json:"response"`
@@ -99,7 +99,7 @@ func TestOllamaGenerateStreamNDJSONEndsDone(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/generate",
 		strings.NewReader(`{"model":"llama3.2","prompt":"hi"}`)) // stream defaults true
 	rec := httptest.NewRecorder()
-	OllamaGenerate(rec, req, "llama3.2")
+	OllamaGenerate(rec, req, Profile{DefaultModel: "llama3.2"})
 	lines := strings.Split(strings.TrimSpace(rec.Body.String()), "\n")
 	if len(lines) < 2 {
 		t.Fatalf("want multiple NDJSON lines, got %d", len(lines))

--- a/llmcore/llmcore.go
+++ b/llmcore/llmcore.go
@@ -100,11 +100,32 @@ func captureAndSave(r *http.Request, save func(*proto.LlmRequest) error) {
 	}(in)
 }
 
+// writeCompactJSON marshals v with no trailing newline. json.Encoder.Encode appends one,
+// which inflates Content-Length by a byte relative to every real server we emulate (Gin,
+// FastAPI and Fiber all write the marshalled bytes directly) — a free fingerprint.
+//
+// Callers should pass structs with the field order of the product being emulated rather than
+// map[string]any: encoding/json sorts map keys alphabetically, so a map-built body has a key
+// order no real implementation produces.
+func writeCompactJSON(w http.ResponseWriter, v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	_, _ = w.Write(b)
+}
+
 // WriteJSON marshals v and writes it with the given status and application/json.
 func WriteJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
+	WriteJSONCT(w, status, CTJSON, v)
+}
+
+// WriteJSONCT is WriteJSON with an explicit content type, so callers can pick the charset
+// suffix their framework would emit (see the CT* constants).
+func WriteJSONCT(w http.ResponseWriter, status int, contentType string, v any) {
+	w.Header().Set("Content-Type", contentType)
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	writeCompactJSON(w, v)
 }
 
 // WriteError writes an OpenAI-style error envelope: {"error":{"message","type","code"}}.

--- a/llmcore/profile.go
+++ b/llmcore/profile.go
@@ -1,0 +1,100 @@
+package llmcore
+
+import "net/http"
+
+// JSON content types. Products differ in whether their web framework appends a charset, and
+// scanners can tell them apart on that alone: Gin (Ollama's /api/*) and cpp-httplib
+// (llama.cpp) append "; charset=utf-8"; FastAPI (vLLM), Fiber (LocalAI) and Ollama's own
+// OpenAI-compat layer (/v1/*) do not.
+const (
+	CTJSON        = "application/json"
+	CTJSONCharset = "application/json; charset=utf-8"
+	CTNDJSON      = "application/x-ndjson"
+	CTText        = "text/plain"
+	CTTextCharset = "text/plain; charset=utf-8"
+	CTEventStream = "text/event-stream"
+)
+
+// Profile describes how one product's HTTP surface behaves on the wire. The generators are
+// shared across all six LLM honeypots; the per-product differences that a fingerprinting
+// scanner can observe live here rather than being hardcoded into each generator.
+type Profile struct {
+	// DefaultModel is used when the request body names no model.
+	DefaultModel string
+	// ContentType is the JSON content type for this surface. Defaults to CTJSON.
+	ContentType string
+	// SystemFingerprint is echoed in OpenAI-shaped responses ("fp_ollama" for Ollama).
+	// Empty omits the field entirely, which is what vLLM does.
+	SystemFingerprint string
+	// ShortIDs makes completion ids look like Ollama's ("chatcmpl-964") rather than the
+	// long opaque ids OpenAI and vLLM emit.
+	ShortIDs bool
+	// KnownModel reports whether a model exists in this instance's catalog. nil accepts any
+	// model; a non-nil predicate makes the surface return a faithful model-not-found error,
+	// which is what a real server does for a name it has not pulled.
+	KnownModel func(string) bool
+}
+
+func (p Profile) ct() string {
+	if p.ContentType == "" {
+		return CTJSON
+	}
+	return p.ContentType
+}
+
+// known reports whether model is servable under this profile.
+func (p Profile) known(model string) bool {
+	return p.KnownModel == nil || p.KnownModel(model)
+}
+
+// resolveModel returns the requested model (or the profile default) plus whether the surface
+// should serve it. Callers write the product-appropriate not-found error when ok is false.
+func (p Profile) resolveModel(body []byte) (model string, ok bool) {
+	model = modelOr(body, p.DefaultModel)
+	return model, p.known(model)
+}
+
+// Error envelopes are structs, not maps: encoding/json sorts map keys alphabetically, which
+// would emit {"code":…,"message":…,"param":…,"type":…} where every real server emits
+// {"message":…,"type":…,"param":…,"code":…}.
+
+type openAIErrorBody struct {
+	Message string  `json:"message"`
+	Type    string  `json:"type"`
+	Param   *string `json:"param"`
+	Code    *string `json:"code"`
+}
+
+type openAIErrorEnvelope struct {
+	Error openAIErrorBody `json:"error"`
+}
+
+type ollamaErrorEnvelope struct {
+	Error string `json:"error"`
+}
+
+// WriteOpenAIError writes the OpenAI error envelope used by /v1/* surfaces:
+// {"error":{"message":…,"type":…,"param":null,"code":null}}. Matches Ollama's OpenAI-compat
+// layer byte-for-byte, including the explicit nulls and their position.
+func WriteOpenAIError(w http.ResponseWriter, p Profile, status int, message, errType string) {
+	w.Header().Set("Content-Type", CTJSON)
+	w.WriteHeader(status)
+	writeCompactJSON(w, openAIErrorEnvelope{Error: openAIErrorBody{Message: message, Type: errType}})
+}
+
+// WriteOllamaError writes the flat {"error":"…"} envelope Ollama's native /api/* routes use.
+func WriteOllamaError(w http.ResponseWriter, p Profile, status int, message string) {
+	w.Header().Set("Content-Type", p.ct())
+	w.WriteHeader(status)
+	writeCompactJSON(w, ollamaErrorEnvelope{Error: message})
+}
+
+// WriteModelNotFoundV1 is the /v1/* model-not-found response.
+func WriteModelNotFoundV1(w http.ResponseWriter, p Profile, model string) {
+	WriteOpenAIError(w, p, http.StatusNotFound, "model '"+model+"' not found", "not_found_error")
+}
+
+// WriteModelNotFoundAPI is the /api/* model-not-found response.
+func WriteModelNotFoundAPI(w http.ResponseWriter, p Profile, model string) {
+	WriteOllamaError(w, p, http.StatusNotFound, "model '"+model+"' not found")
+}

--- a/llmcore/responses.go
+++ b/llmcore/responses.go
@@ -1,0 +1,136 @@
+package llmcore
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+// The OpenAI Responses API (/v1/responses). Captured prod traffic shows open-router-cli probing
+// this endpoint with models the honeypot advertises, so a 404 here fails a validator that a real
+// modern Ollama would have passed. Field order and the explicit nulls mirror a real response.
+
+type responseOutputContent struct {
+	Type        string `json:"type"`
+	Text        string `json:"text"`
+	Annotations []any  `json:"annotations"`
+	Logprobs    []any  `json:"logprobs"`
+}
+
+type responseOutput struct {
+	ID      string                  `json:"id"`
+	Type    string                  `json:"type"`
+	Status  string                  `json:"status"`
+	Role    string                  `json:"role"`
+	Content []responseOutputContent `json:"content"`
+}
+
+type responseTextFormat struct {
+	Type string `json:"type"`
+}
+
+type responseText struct {
+	Format responseTextFormat `json:"format"`
+}
+
+type responseUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+type responsesPayload struct {
+	ID                 string           `json:"id"`
+	Object             string           `json:"object"`
+	CreatedAt          int64            `json:"created_at"`
+	CompletedAt        int64            `json:"completed_at"`
+	Status             string           `json:"status"`
+	IncompleteDetails  *string          `json:"incomplete_details"`
+	Model              string           `json:"model"`
+	PreviousResponseID *string          `json:"previous_response_id"`
+	Instructions       *string          `json:"instructions"`
+	Output             []responseOutput `json:"output"`
+	Error              *string          `json:"error"`
+	Tools              []any            `json:"tools"`
+	ToolChoice         string           `json:"tool_choice"`
+	Truncation         string           `json:"truncation"`
+	ParallelToolCalls  bool             `json:"parallel_tool_calls"`
+	Text               responseText     `json:"text"`
+	TopP               float64          `json:"top_p"`
+	PresencePenalty    float64          `json:"presence_penalty"`
+	FrequencyPenalty   float64          `json:"frequency_penalty"`
+	TopLogprobs        int              `json:"top_logprobs"`
+	Temperature        float64          `json:"temperature"`
+	Reasoning          *string          `json:"reasoning"`
+	Usage              responseUsage    `json:"usage"`
+}
+
+// Responses writes an OpenAI Responses API (/v1/responses) reply.
+func Responses(w http.ResponseWriter, r *http.Request, p Profile) {
+	body := readBody(r)
+	if msg, ok := ValidJSONBody(body); !ok {
+		WriteOpenAIError(w, p, http.StatusBadRequest, msg, "invalid_request_error")
+		return
+	}
+	model, known := p.resolveModel(body)
+	if !known {
+		WriteModelNotFoundV1(w, p, model)
+		return
+	}
+	prompt := promptText(body)
+	reply, chunks, _ := capReply(smartReply(prompt), maxTokensOf(body))
+	now := time.Now().Unix()
+	in := promptTokensFor(prompt)
+
+	WriteJSONCT(w, http.StatusOK, CTJSON, responsesPayload{
+		ID:        fmt.Sprintf("resp_%d", rand.Intn(100000)),
+		Object:    "response",
+		CreatedAt: now, CompletedAt: now,
+		Status: "completed",
+		Model:  model,
+		Output: []responseOutput{{
+			ID:     fmt.Sprintf("msg_%d", rand.Intn(1000000)),
+			Type:   "message",
+			Status: "completed",
+			Role:   "assistant",
+			Content: []responseOutputContent{{
+				Type: "output_text", Text: reply,
+				Annotations: []any{}, Logprobs: []any{},
+			}},
+		}},
+		Tools: []any{}, ToolChoice: "auto", Truncation: "disabled",
+		ParallelToolCalls: true,
+		Text:              responseText{Format: responseTextFormat{Type: "text"}},
+		TopP:              1, Temperature: 1,
+		Usage: responseUsage{InputTokens: in, OutputTokens: len(chunks), TotalTokens: in + len(chunks)},
+	})
+}
+
+// PromptOf returns the prompt/input text from a request body, for surfaces that need it outside
+// the generators (vLLM's /tokenize, for instance).
+func PromptOf(r *http.Request) string { return promptText(readBody(r)) }
+
+// PseudoTokens produces a plausible token-id sequence for text. Used by /tokenize, where the
+// count and rough shape are what a caller checks, not the specific vocabulary indices.
+func PseudoTokens(text string) []int {
+	n := estTokens(text)
+	out := make([]int, 0, n+1)
+	out = append(out, 128000) // BOS
+	for i := 0; i < n; i++ {
+		out = append(out, 1000+rand.Intn(126000))
+	}
+	return out
+}
+
+// WriteEmbeddingsUnsupported reproduces the 501 a real Ollama returns when the requested model
+// has no embedding support — which is true of every model in the advertised catalog. Fabricating
+// a plausible embedding vector would be more work and less accurate than the real refusal.
+func WriteEmbeddingsUnsupported(w http.ResponseWriter, p Profile, openAIShape bool) {
+	const msg = "This server does not support embeddings. Start it with `--embeddings`"
+	if openAIShape {
+		WriteOpenAIError(w, p, http.StatusNotImplemented, msg, "api_error")
+		return
+	}
+	WriteOllamaError(w, p, http.StatusNotImplemented, msg)
+}

--- a/llmcore/smartreply_test.go
+++ b/llmcore/smartreply_test.go
@@ -50,7 +50,7 @@ func TestChatCompletionAnswersLivenessProbe(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
 		strings.NewReader(`{"model":"llama3.2","messages":[{"role":"user","content":"say pong"}]}`))
 	rec := httptest.NewRecorder()
-	ChatCompletion(rec, req, "gpt-3.5-turbo")
+	ChatCompletion(rec, req, Profile{DefaultModel: "gpt-3.5-turbo"})
 	var resp struct {
 		Choices []struct {
 			Message struct {
@@ -70,7 +70,7 @@ func TestOllamaGenerateAnswersArithmetic(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/generate",
 		strings.NewReader(`{"model":"llama3.2","prompt":"what is 2+2","stream":false}`))
 	rec := httptest.NewRecorder()
-	OllamaGenerate(rec, req, "llama3.2")
+	OllamaGenerate(rec, req, Profile{DefaultModel: "llama3.2"})
 	var resp struct {
 		Response string `json:"response"`
 	}

--- a/llmcore/timings.go
+++ b/llmcore/timings.go
@@ -1,0 +1,127 @@
+package llmcore
+
+import (
+	"encoding/json"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// Timings are the nanosecond durations a real inference server reports alongside a completion.
+// The previous implementation returned the same five constants on every request, so two
+// requests from the same scanner produced byte-identical duration fields — a decisive tell.
+// These are derived from the request's own token counts with jitter, and honour whether the
+// model is already resident (see loadState).
+type Timings struct {
+	Total      time.Duration
+	Load       time.Duration
+	PromptEval time.Duration
+	Eval       time.Duration
+}
+
+// Per-token costs and cold-start ranges, taken from a real Ollama 0.30.11 running a 7B Q4_K_M
+// model: prompt eval ~3.5-7.2ms/token, generation ~17-18ms/token, cold load 1.5-4.8s, warm load
+// single-digit-to-low-double-digit ms.
+const (
+	promptEvalPerTokenMin = 3200 * time.Microsecond
+	promptEvalPerTokenMax = 7400 * time.Microsecond
+	evalPerTokenMin       = 14 * time.Millisecond
+	evalPerTokenMax       = 21 * time.Millisecond
+	coldLoadMin           = 1400 * time.Millisecond
+	coldLoadMax           = 4800 * time.Millisecond
+	warmLoadMin           = 8 * time.Millisecond
+	warmLoadMax           = 35 * time.Millisecond
+	// defaultKeepAlive matches Ollama's own 5m default for how long a model stays resident.
+	defaultKeepAlive = 5 * time.Minute
+)
+
+// loadState tracks which models are "resident", so a repeated request reports a warm load
+// duration and a request after keep_alive expiry reports a cold one. A scanner that probes the
+// same endpoint twice sees the second call get faster, exactly as a real server behaves.
+type loadState struct {
+	mu       sync.Mutex
+	residing map[string]time.Time // model -> unload deadline
+}
+
+var models = &loadState{residing: map[string]time.Time{}}
+
+// touch marks model resident for d and reports whether it was already resident beforehand.
+// A d of zero unloads immediately, mirroring "keep_alive": 0.
+func (s *loadState) touch(model string, d time.Duration) (wasWarm bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	deadline, ok := s.residing[model]
+	wasWarm = ok && now.Before(deadline)
+	if d <= 0 {
+		delete(s.residing, model)
+		return wasWarm
+	}
+	s.residing[model] = now.Add(d)
+	return wasWarm
+}
+
+// ResidentModels returns the models currently held "in memory" with their unload deadlines.
+// Ollama's /api/ps reports exactly this, so an attacker who runs a completion and then checks
+// /api/ps sees the model they just used listed as loaded — and sees it disappear later.
+func ResidentModels() map[string]time.Time {
+	models.mu.Lock()
+	defer models.mu.Unlock()
+	now := time.Now()
+	out := map[string]time.Time{}
+	for name, deadline := range models.residing {
+		if now.Before(deadline) {
+			out[name] = deadline
+		} else {
+			delete(models.residing, name)
+		}
+	}
+	return out
+}
+
+func jitter(min, max time.Duration) time.Duration {
+	if max <= min {
+		return min
+	}
+	return min + time.Duration(rand.Int63n(int64(max-min)))
+}
+
+// keepAliveOf reads the request's "keep_alive" field. Ollama accepts a duration string ("10m")
+// or a number of seconds; anything absent or unparseable means the 5m default.
+func keepAliveOf(body []byte) time.Duration {
+	var m struct {
+		KeepAlive json.RawMessage `json:"keep_alive"`
+	}
+	if err := json.Unmarshal(body, &m); err != nil || len(m.KeepAlive) == 0 {
+		return defaultKeepAlive
+	}
+	var secs float64
+	if err := json.Unmarshal(m.KeepAlive, &secs); err == nil {
+		return time.Duration(secs * float64(time.Second))
+	}
+	var s string
+	if err := json.Unmarshal(m.KeepAlive, &s); err == nil {
+		if d, err := time.ParseDuration(s); err == nil {
+			return d
+		}
+	}
+	return defaultKeepAlive
+}
+
+// newTimings synthesises a plausible timing breakdown for one completion.
+func newTimings(model string, keepAlive time.Duration, promptTokens, evalTokens int) Timings {
+	warm := models.touch(model, keepAlive)
+
+	load := jitter(coldLoadMin, coldLoadMax)
+	if warm {
+		load = jitter(warmLoadMin, warmLoadMax)
+	}
+	t := Timings{
+		Load:       load,
+		PromptEval: time.Duration(promptTokens) * jitter(promptEvalPerTokenMin, promptEvalPerTokenMax),
+		Eval:       time.Duration(evalTokens) * jitter(evalPerTokenMin, evalPerTokenMax),
+	}
+	// Real total_duration exceeds the sum of its parts by the request/sampling overhead.
+	t.Total = t.Load + t.PromptEval + t.Eval + jitter(500*time.Microsecond, 4*time.Millisecond)
+	return t
+}

--- a/localai/localai.go
+++ b/localai/localai.go
@@ -40,15 +40,18 @@ func (h *honeypot) Start() {
 	h.logger.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%s", port), handler)).Msg("failed to start")
 }
 
+// profile: LocalAI is a Go/Fiber service, so bare application/json and no system_fingerprint.
+var profile = llmcore.Profile{DefaultModel: defaultModel, ContentType: llmcore.CTJSON}
+
 func newRouter() http.Handler {
 	r := mux.NewRouter()
 	r.HandleFunc("/v1/models", handleModels).Methods("GET")
 	r.HandleFunc("/models", handleModels).Methods("GET")
 	r.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.ChatCompletion(w, req, defaultModel)
+		llmcore.ChatCompletion(w, req, profile)
 	}).Methods("POST")
 	r.HandleFunc("/v1/completions", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.Completion(w, req, defaultModel)
+		llmcore.Completion(w, req, profile)
 	}).Methods("POST")
 	r.HandleFunc("/readyz", func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusOK) }).Methods("GET")
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/ollama/catalog.go
+++ b/ollama/catalog.go
@@ -1,0 +1,266 @@
+package ollama
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Details mirrors the "details" object in Ollama's /api/tags and /api/show payloads. Field
+// order matches the real server's struct order — encoding/json sorts map keys alphabetically,
+// so building these from maps produces an ordering no real Ollama emits.
+type Details struct {
+	ParentModel       string   `json:"parent_model"`
+	Format            string   `json:"format"`
+	Family            string   `json:"family"`
+	Families          []string `json:"families"`
+	ParameterSize     string   `json:"parameter_size"`
+	QuantizationLevel string   `json:"quantization_level"`
+	ContextLength     int      `json:"context_length,omitempty"`
+	EmbeddingLength   int      `json:"embedding_length,omitempty"`
+}
+
+// CatalogModel is one locally-present model.
+type CatalogModel struct {
+	Name         string   `json:"name"`
+	Model        string   `json:"model"`
+	ModifiedAt   string   `json:"modified_at"`
+	Size         int64    `json:"size"`
+	Digest       string   `json:"digest"`
+	Details      Details  `json:"details"`
+	Capabilities []string `json:"capabilities"`
+
+	// arch is the GGUF architecture prefix used to synthesise /api/show model_info keys.
+	arch string `json:"-"`
+	// blocks is the transformer layer count, used for the /api/show tensor listing.
+	blocks int `json:"-"`
+}
+
+// seedModels is the advertised catalog. llama3.2:latest and mistral:latest are kept byte-identical
+// to what the honeypot has been serving since July — captured traffic shows scanners read
+// /api/tags and then probe exactly the names they find there, so renaming them would break the
+// validation loop that is already working. The other four widen the surface: since off-catalog
+// models now get a faithful 404 (a real box only serves what its owner pulled), the way to keep
+// probes landing is to stock a bigger shelf, not to answer for models we do not list.
+var seedModels = []CatalogModel{
+	{
+		Name: "llama3.2:latest", Model: "llama3.2:latest",
+		Size:   2019393189,
+		Digest: "a80c4f17acd55265feb1f6c8f10a0b2b6b6c7f8a9b0c1d2e3f4a5b6c7d8e9f0a1",
+		Details: Details{
+			Format: "gguf", Family: "llama", Families: []string{"llama"},
+			ParameterSize: "3.2B", QuantizationLevel: "Q4_K_M",
+			ContextLength: 131072, EmbeddingLength: 3072,
+		},
+		Capabilities: []string{"completion", "tools"},
+		arch:         "llama", blocks: 28,
+	},
+	{
+		Name: "mistral:latest", Model: "mistral:latest",
+		Size:   4113301824,
+		Digest: "61e88e884507ba5e06c49b40e6226884b2a16e872382c2b44a42f2d119d804a5",
+		Details: Details{
+			Format: "gguf", Family: "llama", Families: []string{"llama"},
+			ParameterSize: "7.2B", QuantizationLevel: "Q4_0",
+			ContextLength: 32768, EmbeddingLength: 4096,
+		},
+		Capabilities: []string{"completion", "tools"},
+		arch:         "llama", blocks: 32,
+	},
+	{
+		Name: "qwen2.5-coder:7b", Model: "qwen2.5-coder:7b",
+		Size:   4683087561,
+		Digest: "dae161e27b0e90dd1856c8bb3209201fd6736d8eb66298e75ed87571486f4364",
+		Details: Details{
+			Format: "gguf", Family: "qwen2", Families: []string{"qwen2"},
+			ParameterSize: "7.6B", QuantizationLevel: "Q4_K_M",
+			ContextLength: 32768, EmbeddingLength: 3584,
+		},
+		Capabilities: []string{"completion", "tools", "insert"},
+		arch:         "qwen2", blocks: 28,
+	},
+	{
+		Name: "gemma3:12b", Model: "gemma3:12b",
+		Size:   8149190253,
+		Digest: "f4031aab637d1ffa37b42570452ae0e4fad0314754d17ded67322e4b95836f8a",
+		Details: Details{
+			Format: "gguf", Family: "gemma3", Families: []string{"gemma3"},
+			ParameterSize: "12.2B", QuantizationLevel: "Q4_K_M",
+			ContextLength: 131072, EmbeddingLength: 3840,
+		},
+		Capabilities: []string{"completion", "vision"},
+		arch:         "gemma3", blocks: 48,
+	},
+	{
+		Name: "deepseek-r1:8b", Model: "deepseek-r1:8b",
+		Size:   4920738147,
+		Digest: "6995872bfe4c5b2b0e3b1a9c48ec1e2ba1b7f6b4ba9d40e1e4c0e6a0b5f2c3d7",
+		Details: Details{
+			Format: "gguf", Family: "qwen3", Families: []string{"qwen3"},
+			ParameterSize: "8.2B", QuantizationLevel: "Q4_K_M",
+			ContextLength: 131072, EmbeddingLength: 4096,
+		},
+		Capabilities: []string{"completion", "thinking"},
+		arch:         "qwen3", blocks: 36,
+	},
+	{
+		Name: "llava:latest", Model: "llava:latest",
+		Size:   4733363377,
+		Digest: "8dd30f6b0cb19f555f2c7a7ebda861449ea2cc76bf1f44e262931f45fc81d081",
+		Details: Details{
+			Format: "gguf", Family: "llama", Families: []string{"llama", "clip"},
+			ParameterSize: "7B", QuantizationLevel: "Q4_0",
+			ContextLength: 32768, EmbeddingLength: 4096,
+		},
+		Capabilities: []string{"completion", "vision"},
+		arch:         "llama", blocks: 32,
+	},
+}
+
+// catalog is the instance's model list. It is mutable because /api/pull adds to it: an attacker
+// who pulls a model and then finds it in /api/tags will go on to use it, which is exactly the
+// traffic worth capturing.
+type catalog struct {
+	mu     sync.RWMutex
+	models []CatalogModel
+}
+
+var models = newCatalog()
+
+func newCatalog() *catalog {
+	c := &catalog{models: make([]CatalogModel, len(seedModels))}
+	copy(c.models, seedModels)
+	// Stagger the timestamps so the catalog looks accumulated over time rather than seeded at
+	// once. Computed at startup and stable thereafter: a scanner polling twice must see the
+	// same values.
+	base := time.Now().UTC().Add(-27 * 24 * time.Hour)
+	for i := range c.models {
+		c.models[i].ModifiedAt = base.
+			Add(time.Duration(i) * 53 * time.Hour).
+			Add(time.Duration(i*7919) * time.Millisecond).
+			Format(time.RFC3339Nano)
+	}
+	return c
+}
+
+// normalize applies Ollama's implicit ":latest" tag so "llama3.2" and "llama3.2:latest" resolve
+// to the same entry, as they do on a real server.
+func normalize(name string) string {
+	n := strings.TrimSpace(name)
+	if n == "" {
+		return ""
+	}
+	if !strings.Contains(n, ":") {
+		return n + ":latest"
+	}
+	return n
+}
+
+func (c *catalog) list() []CatalogModel {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]CatalogModel, len(c.models))
+	copy(out, c.models)
+	return out
+}
+
+func (c *catalog) get(name string) (CatalogModel, bool) {
+	n := normalize(name)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, m := range c.models {
+		if m.Name == n {
+			return m, true
+		}
+	}
+	return CatalogModel{}, false
+}
+
+func (c *catalog) has(name string) bool {
+	_, ok := c.get(name)
+	return ok
+}
+
+// add records a model as locally present. Called by /api/pull once the fake download
+// "completes"; a no-op if the model is already listed.
+func (c *catalog) add(m CatalogModel) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, existing := range c.models {
+		if existing.Name == m.Name {
+			return
+		}
+	}
+	c.models = append(c.models, m)
+}
+
+// remove drops a model, backing /api/delete.
+func (c *catalog) remove(name string) bool {
+	n := normalize(name)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for i, m := range c.models {
+		if m.Name == n {
+			c.models = append(c.models[:i], c.models[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// synthesize builds a plausible catalog entry for a model an attacker pulled. Parameter size and
+// footprint are inferred from the tag (":1b", ":70b", …) so a pulled llama3.2:1b does not claim
+// to be the same size as a 70B.
+func synthesize(name string) CatalogModel {
+	n := normalize(name)
+	tag := ""
+	if i := strings.LastIndex(n, ":"); i >= 0 {
+		tag = strings.ToLower(n[i+1:])
+	}
+	params, size := "7B", int64(4113301824)
+	ctx, embd, blocks := 32768, 4096, 32
+	switch {
+	case strings.HasPrefix(tag, "0.5b"), strings.HasPrefix(tag, "1b"):
+		params, size, embd, blocks = "1.2B", 1321098329, 2048, 16
+	case strings.HasPrefix(tag, "1.5b"), strings.HasPrefix(tag, "2b"):
+		params, size, embd, blocks = "1.8B", 1629518745, 2048, 24
+	case strings.HasPrefix(tag, "3b"):
+		params, size, embd, blocks = "3.2B", 2019393189, 3072, 28
+	case strings.HasPrefix(tag, "13b"), strings.HasPrefix(tag, "14b"):
+		params, size, embd, blocks = "13.0B", 7365960935, 5120, 40
+	case strings.HasPrefix(tag, "32b"), strings.HasPrefix(tag, "34b"):
+		params, size, embd, blocks = "32.8B", 19851349898, 5120, 64
+	case strings.HasPrefix(tag, "70b"):
+		params, size, embd, blocks = "70.6B", 39969734263, 8192, 80
+	}
+	return CatalogModel{
+		Name: n, Model: n,
+		ModifiedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Size:       size,
+		Digest:     pseudoDigest(n),
+		Details: Details{
+			Format: "gguf", Family: "llama", Families: []string{"llama"},
+			ParameterSize: params, QuantizationLevel: "Q4_K_M",
+			ContextLength: ctx, EmbeddingLength: embd,
+		},
+		Capabilities: []string{"completion", "tools"},
+		arch:         "llama", blocks: blocks,
+	}
+}
+
+// pseudoDigest derives a stable 64-hex-character digest from a model name, so the same pulled
+// model always reports the same digest across /api/tags and /api/show.
+func pseudoDigest(name string) string {
+	// FNV-1a, expanded to 32 bytes by re-hashing with a counter.
+	var out strings.Builder
+	for i := 0; i < 4; i++ {
+		h := uint64(1469598103934665603)
+		for _, b := range []byte(fmt.Sprintf("%s/%d", name, i)) {
+			h ^= uint64(b)
+			h *= 1099511628211
+		}
+		fmt.Fprintf(&out, "%016x", h)
+	}
+	return out.String()
+}

--- a/ollama/fidelity_test.go
+++ b/ollama/fidelity_test.go
@@ -1,0 +1,422 @@
+package ollama
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for PRD 033. Every expectation here was captured from a real Ollama 0.30.11,
+// not from documentation — the reference transcript is quoted inline per assertion. A scanner
+// that has touched a genuine Ollama can distinguish it from ours on any of these, so each one
+// that regresses is a fingerprint the honeypot leaks.
+
+func do(t *testing.T, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	rec := httptest.NewRecorder()
+	buildHandler().ServeHTTP(rec, r)
+	return rec
+}
+
+// Real: no Server header on any response. Ollama is Gin; Gin never sets one.
+func TestNoServerHeaderAnywhere(t *testing.T) {
+	for _, tc := range []struct{ method, path, body string }{
+		{"GET", "/", ""},
+		{"GET", "/api/tags", ""},
+		{"GET", "/api/version", ""},
+		{"GET", "/v1/models", ""},
+		{"GET", "/definitely-not-a-route", ""},
+		{"POST", "/api/chat", `{"model":"llama3.2:latest","messages":[{"role":"user","content":"hi"}],"stream":false}`},
+	} {
+		if got := do(t, tc.method, tc.path, tc.body).Header().Get("Server"); got != "" {
+			t.Errorf("%s %s: Server header set to %q; real Ollama sends none", tc.method, tc.path, got)
+		}
+	}
+}
+
+// Real: /api/* is "application/json; charset=utf-8" (Gin), /v1/* is bare "application/json"
+// (the OpenAI-compat layer). Serving one charset convention everywhere is a tell.
+func TestContentTypeCharsetSplit(t *testing.T) {
+	for _, tc := range []struct{ path, want string }{
+		{"/api/tags", "application/json; charset=utf-8"},
+		{"/api/version", "application/json; charset=utf-8"},
+		{"/api/ps", "application/json; charset=utf-8"},
+		{"/v1/models", "application/json"},
+	} {
+		if got := do(t, "GET", tc.path, "").Header().Get("Content-Type"); got != tc.want {
+			t.Errorf("%s: content-type %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+// Real: `404 page not found`, Content-Type text/plain (no charset), Content-Length 18.
+func TestNotFoundIsGinPlainText(t *testing.T) {
+	// /props and /metrics are both observed in prod against the ollama port.
+	for _, path := range []string{"/props", "/metrics", "/nonexistent-xyz"} {
+		rec := do(t, "GET", path, "")
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s: status %d, want 404", path, rec.Code)
+		}
+		if got := rec.Header().Get("Content-Type"); got != "text/plain" {
+			t.Errorf("%s: content-type %q, want text/plain", path, got)
+		}
+		if got := rec.Body.String(); got != "404 page not found" {
+			t.Errorf("%s: body %q, want %q", path, got, "404 page not found")
+		}
+	}
+}
+
+// Real: GET /api/generate -> 405, Allow: POST, body "405 method not allowed".
+func TestMethodNotAllowedCarriesAllow(t *testing.T) {
+	rec := do(t, "GET", "/api/generate", "")
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status %d, want 405", rec.Code)
+	}
+	if got := rec.Header().Get("Allow"); got != "POST" {
+		t.Errorf("Allow %q, want POST", got)
+	}
+	if got := rec.Body.String(); got != "405 method not allowed" {
+		t.Errorf("body %q", got)
+	}
+}
+
+// Real: HEAD / -> 200 with Content-Length 17. gorilla/mux does not imply HEAD from GET, so this
+// used to fall through to the 404 handler.
+func TestHeadRootAnswers200(t *testing.T) {
+	rec := do(t, "HEAD", "/", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Length"); got != "17" {
+		t.Errorf("Content-Length %q, want 17", got)
+	}
+}
+
+// Real (OLLAMA_ORIGINS=*): preflight -> 204 with the X-Stainless-* allow-header list.
+func TestCORSPreflight(t *testing.T) {
+	rec := do(t, "OPTIONS", "/api/chat", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204", rec.Code)
+	}
+	h := rec.Header()
+	if h.Get("Access-Control-Allow-Origin") != "*" {
+		t.Errorf("allow-origin %q", h.Get("Access-Control-Allow-Origin"))
+	}
+	if !strings.Contains(h.Get("Access-Control-Allow-Headers"), "X-Stainless-Retry-Count") {
+		t.Errorf("allow-headers missing the OpenAI SDK telemetry headers: %q", h.Get("Access-Control-Allow-Headers"))
+	}
+	if h.Get("Access-Control-Max-Age") != "43200" {
+		t.Errorf("max-age %q, want 43200", h.Get("Access-Control-Max-Age"))
+	}
+}
+
+// Real: a model the box has not pulled 404s. /api/* uses {"error":"model 'x' not found"};
+// /v1/* uses the OpenAI envelope with explicit nulls.
+func TestUnknownModelIsRejected(t *testing.T) {
+	rec := do(t, "POST", "/api/chat", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}],"stream":false}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/api/chat unknown model: status %d, want 404", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"model 'gpt-4o' not found"}` {
+		t.Errorf("/api/chat body %q", got)
+	}
+
+	rec = do(t, "POST", "/v1/chat/completions", `{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("/v1 unknown model: status %d, want 404", rec.Code)
+	}
+	want := `{"error":{"message":"model 'gpt-4o' not found","type":"not_found_error","param":null,"code":null}}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("/v1 body:\n got %s\nwant %s", got, want)
+	}
+}
+
+// The two names captured traffic actually probes must keep working.
+func TestAdvertisedModelsStillServe(t *testing.T) {
+	for _, m := range []string{"llama3.2:latest", "mistral:latest"} {
+		rec := do(t, "POST", "/api/chat",
+			`{"model":"`+m+`","messages":[{"role":"user","content":"Hello"}],"stream":false}`)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: status %d, want 200", m, rec.Code)
+		}
+	}
+	// And every advertised model must be servable, or the catalog is lying.
+	for _, m := range models.list() {
+		rec := do(t, "POST", "/api/generate", `{"model":"`+m.Name+`","prompt":"hi","stream":false}`)
+		if rec.Code != http.StatusOK {
+			t.Errorf("advertised model %s not servable: status %d", m.Name, rec.Code)
+		}
+	}
+}
+
+// Real: malformed JSON -> 400 with the parse error echoed.
+func TestMalformedJSONIsRejected(t *testing.T) {
+	rec := do(t, "POST", "/api/generate", `not-json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"error"`) {
+		t.Errorf("body %q", rec.Body.String())
+	}
+}
+
+// Real: POST /api/show {} -> 400 {"error":"model is required"}.
+func TestShowRequiresModel(t *testing.T) {
+	rec := do(t, "POST", "/api/show", `{}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"model is required"}` {
+		t.Errorf("body %q", got)
+	}
+}
+
+// Real /api/show carries model_info (~36 keys), a tensor inventory and capabilities. The old
+// five-key stub was recognisable at a glance.
+func TestShowIsDetailed(t *testing.T) {
+	rec := do(t, "POST", "/api/show", `{"model":"llama3.2:latest"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var resp showResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.ModelInfo) < 15 {
+		t.Errorf("model_info has %d keys, real responses carry ~36", len(resp.ModelInfo))
+	}
+	if len(resp.Tensors) < 50 {
+		t.Errorf("tensors has %d entries, real responses list one per layer", len(resp.Tensors))
+	}
+	if len(resp.Capabilities) == 0 {
+		t.Error("capabilities missing")
+	}
+}
+
+// /api/pull is observed in prod from three distinct IPs pulling llama3.2:1b. It must stream
+// progress and leave the model listed, so the attacker goes on to use it.
+func TestPullStreamsAndRegistersModel(t *testing.T) {
+	orig := pullStepDelay
+	pullStepDelay = func() time.Duration { return 0 }
+	t.Cleanup(func() { pullStepDelay = orig })
+
+	const name = "llama3.2:1b"
+	t.Cleanup(func() { models.remove(name) })
+
+	rec := do(t, "POST", "/api/pull", `{"name":"`+name+`"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/x-ndjson" {
+		t.Errorf("content-type %q, want application/x-ndjson", got)
+	}
+	lines := strings.Split(strings.TrimSpace(rec.Body.String()), "\n")
+	if len(lines) < 5 {
+		t.Fatalf("expected a progress stream, got %d lines", len(lines))
+	}
+	if !strings.Contains(lines[0], "pulling manifest") {
+		t.Errorf("first line %q, want pulling manifest", lines[0])
+	}
+	if !strings.Contains(lines[len(lines)-1], `"success"`) {
+		t.Errorf("last line %q, want success", lines[len(lines)-1])
+	}
+	// Every line must be valid JSON: a client streaming NDJSON will choke otherwise.
+	for i, ln := range lines {
+		var v map[string]any
+		if err := json.Unmarshal([]byte(ln), &v); err != nil {
+			t.Fatalf("line %d is not JSON: %q", i, ln)
+		}
+	}
+	if !models.has(name) {
+		t.Fatal("pulled model did not appear in the catalog")
+	}
+	// ...and is now servable and listed, which is the point of the divergence.
+	if rec := do(t, "POST", "/api/generate", `{"model":"`+name+`","prompt":"hi","stream":false}`); rec.Code != http.StatusOK {
+		t.Errorf("pulled model not servable: status %d", rec.Code)
+	}
+	if !strings.Contains(do(t, "GET", "/api/tags", "").Body.String(), name) {
+		t.Error("pulled model missing from /api/tags")
+	}
+}
+
+// /v1/responses is probed in prod by open-router-cli using models we advertise. Real modern
+// Ollama implements it, so a 404 fails a validator the honeypot should pass.
+func TestResponsesAPI(t *testing.T) {
+	rec := do(t, "POST", "/v1/responses",
+		`{"model":"mistral:latest","input":"Reply with OK.","temperature":0,"max_output_tokens":1,"stream":false}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	var resp struct {
+		Object string `json:"object"`
+		Status string `json:"status"`
+		Output []struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v — %s", err, rec.Body.String())
+	}
+	if resp.Object != "response" || resp.Status != "completed" {
+		t.Errorf("object=%q status=%q", resp.Object, resp.Status)
+	}
+	if len(resp.Output) == 0 || len(resp.Output[0].Content) == 0 || resp.Output[0].Content[0].Text != "OK" {
+		t.Errorf("echo probe not answered: %s", rec.Body.String())
+	}
+}
+
+// Real: 501, because no model in the catalog has embedding support.
+func TestEmbeddingsReturn501(t *testing.T) {
+	for _, path := range []string{"/api/embed", "/api/embeddings", "/v1/embeddings"} {
+		rec := do(t, "POST", path, `{"model":"mistral:latest","input":"hi"}`)
+		if rec.Code != http.StatusNotImplemented {
+			t.Errorf("%s: status %d, want 501", path, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "does not support embeddings") {
+			t.Errorf("%s: body %q", path, rec.Body.String())
+		}
+	}
+}
+
+// Real bodies are marshalled directly, with no trailing newline; json.Encoder.Encode adds one
+// and inflates Content-Length by a byte against every real server.
+func TestNoTrailingNewlineInJSONBodies(t *testing.T) {
+	for _, path := range []string{"/api/tags", "/api/version", "/api/ps", "/v1/models"} {
+		if body := do(t, "GET", path, "").Body.String(); strings.HasSuffix(body, "\n") {
+			t.Errorf("%s: body has a trailing newline", path)
+		}
+	}
+}
+
+// encoding/json sorts map keys alphabetically; real servers marshal structs, so the key order is
+// declaration order. Building payloads from maps produced an ordering no Ollama emits.
+func TestTagsKeyOrderMatchesReal(t *testing.T) {
+	body := do(t, "GET", "/api/tags", "").Body.String()
+	want := []string{`"name"`, `"model"`, `"modified_at"`, `"size"`, `"digest"`, `"details"`, `"capabilities"`}
+	idx := 0
+	for _, key := range want {
+		i := strings.Index(body[idx:], key)
+		if i < 0 {
+			t.Fatalf("key %s missing or out of order in /api/tags; real order is %v", key, want)
+		}
+		idx += i
+	}
+	// details itself is ordered too.
+	di := strings.Index(body, `"details"`)
+	sub := body[di:]
+	for _, key := range []string{`"parent_model"`, `"format"`, `"family"`, `"families"`, `"parameter_size"`, `"quantization_level"`} {
+		i := strings.Index(sub, key)
+		if i < 0 {
+			t.Fatalf("details key %s missing or out of order", key)
+		}
+		sub = sub[i:]
+	}
+}
+
+// Real: system_fingerprint "fp_ollama" on every /v1 response and every SSE chunk.
+func TestSystemFingerprintPresent(t *testing.T) {
+	rec := do(t, "POST", "/v1/chat/completions",
+		`{"model":"mistral:latest","messages":[{"role":"user","content":"hi"}]}`)
+	if !strings.Contains(rec.Body.String(), `"system_fingerprint":"fp_ollama"`) {
+		t.Errorf("missing system_fingerprint: %s", rec.Body.String())
+	}
+}
+
+// Real: max_tokens=1 truncates and reports finish_reason "length", not "stop".
+func TestMaxTokensProducesLengthFinish(t *testing.T) {
+	rec := do(t, "POST", "/v1/chat/completions",
+		`{"model":"mistral:latest","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":1,"stream":false}`)
+	if !strings.Contains(rec.Body.String(), `"finish_reason":"length"`) {
+		t.Errorf("want finish_reason length: %s", rec.Body.String())
+	}
+	// Ollama's native knob is options.num_predict.
+	rec = do(t, "POST", "/api/chat",
+		`{"model":"mistral:latest","messages":[{"role":"user","content":"Hello"}],"stream":false,"options":{"num_predict":2}}`)
+	if !strings.Contains(rec.Body.String(), `"done_reason":"length"`) {
+		t.Errorf("want done_reason length: %s", rec.Body.String())
+	}
+}
+
+// The old implementation returned these five constants on every request, so two requests from
+// one scanner produced byte-identical duration fields.
+func TestDurationsAreNotConstant(t *testing.T) {
+	const banned = `"total_duration":1234567890`
+	body1 := do(t, "POST", "/api/generate", `{"model":"mistral:latest","prompt":"hi","stream":false}`).Body.String()
+	body2 := do(t, "POST", "/api/generate", `{"model":"mistral:latest","prompt":"hi there friend","stream":false}`).Body.String()
+	for _, b := range []string{body1, body2} {
+		if strings.Contains(b, banned) {
+			t.Fatalf("placeholder duration still present: %s", b)
+		}
+	}
+	re := regexp.MustCompile(`"total_duration":(\d+)`)
+	m1, m2 := re.FindStringSubmatch(body1), re.FindStringSubmatch(body2)
+	if m1 == nil || m2 == nil {
+		t.Fatalf("no total_duration in responses")
+	}
+	if m1[1] == m2[1] {
+		t.Errorf("total_duration identical across two different requests: %s", m1[1])
+	}
+	if !strings.Contains(body1, `"prompt_eval_duration"`) || !strings.Contains(body1, `"context"`) {
+		t.Errorf("/api/generate missing prompt_eval_duration or context: %s", body1)
+	}
+}
+
+// Real streams advance created_at per chunk; ours reused one timestamp for the whole stream.
+func TestStreamTimestampsAdvance(t *testing.T) {
+	rec := do(t, "POST", "/api/generate",
+		`{"model":"mistral:latest","prompt":"tell me about databases","stream":true}`)
+	var stamps []string
+	for _, ln := range strings.Split(strings.TrimSpace(rec.Body.String()), "\n") {
+		var v struct {
+			CreatedAt string `json:"created_at"`
+		}
+		if json.Unmarshal([]byte(ln), &v) == nil && v.CreatedAt != "" {
+			stamps = append(stamps, v.CreatedAt)
+		}
+	}
+	if len(stamps) < 3 {
+		t.Fatalf("expected a multi-chunk stream, got %d chunks", len(stamps))
+	}
+	if stamps[0] == stamps[len(stamps)-1] {
+		t.Errorf("created_at identical across the whole stream (%s)", stamps[0])
+	}
+}
+
+// Real SSE terminates with a literal "data: [DONE]".
+func TestSSETerminator(t *testing.T) {
+	rec := do(t, "POST", "/v1/chat/completions",
+		`{"model":"mistral:latest","messages":[{"role":"user","content":"say pong"}],"max_tokens":20,"stream":true}`)
+	body := rec.Body.String()
+	if !strings.HasSuffix(strings.TrimSpace(body), "data: [DONE]") {
+		t.Errorf("stream does not end with [DONE]: %q", body[max(0, len(body)-80):])
+	}
+	if !strings.Contains(body, `"system_fingerprint":"fp_ollama"`) {
+		t.Errorf("SSE chunks missing system_fingerprint")
+	}
+}
+
+// /api/ps should reflect a model that was just used, and fall off when keep_alive is 0.
+func TestPsReflectsResidency(t *testing.T) {
+	do(t, "POST", "/api/chat",
+		`{"model":"gemma3:12b","messages":[{"role":"user","content":"hi"}],"stream":false}`)
+	if !strings.Contains(do(t, "GET", "/api/ps", "").Body.String(), "gemma3:12b") {
+		t.Error("/api/ps does not list a model that was just used")
+	}
+	do(t, "POST", "/api/chat",
+		`{"model":"gemma3:12b","messages":[{"role":"user","content":"hi"}],"stream":false,"keep_alive":0}`)
+	if strings.Contains(do(t, "GET", "/api/ps", "").Body.String(), "gemma3:12b") {
+		t.Error("/api/ps still lists a model unloaded with keep_alive:0")
+	}
+}

--- a/ollama/models_api.go
+++ b/ollama/models_api.go
@@ -1,0 +1,386 @@
+package ollama
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/joshrendek/threat.gg-agent/llmcore"
+)
+
+// maxBody caps how much of a management-endpoint body we parse. Inference bodies are capped
+// separately inside llmcore.
+const maxBody = 1 << 20
+
+func readJSON(r *http.Request, v any) error {
+	b, err := io.ReadAll(io.LimitReader(r.Body, maxBody))
+	if err != nil {
+		return err
+	}
+	if len(strings.TrimSpace(string(b))) == 0 {
+		return nil
+	}
+	return json.Unmarshal(b, v)
+}
+
+// modelRequest covers the several field names Ollama's management endpoints accept for "which
+// model": /api/show and /api/pull take "model" (with "name" still honoured for compatibility).
+type modelRequest struct {
+	Model  string `json:"model"`
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	Dest   string `json:"destination"`
+}
+
+func (m modelRequest) model() string {
+	if m.Model != "" {
+		return m.Model
+	}
+	return m.Name
+}
+
+// -- /api/show
+
+type showResponse struct {
+	License      string         `json:"license"`
+	Modelfile    string         `json:"modelfile"`
+	Parameters   string         `json:"parameters"`
+	Template     string         `json:"template"`
+	Details      Details        `json:"details"`
+	ModelInfo    map[string]any `json:"model_info"`
+	Tensors      []tensor       `json:"tensors"`
+	Capabilities []string       `json:"capabilities"`
+	ModifiedAt   string         `json:"modified_at"`
+}
+
+type tensor struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Shape []int  `json:"shape"`
+}
+
+// modelInfo synthesises the GGUF metadata block /api/show returns. Real responses carry ~36
+// architecture-prefixed keys; a five-key stub is the giveaway, not the exact values.
+func modelInfo(m CatalogModel) map[string]any {
+	a := m.arch
+	heads := m.Details.EmbeddingLength / 128
+	if heads < 1 {
+		heads = 8
+	}
+	return map[string]any{
+		"general.architecture":                  a,
+		"general.basename":                      strings.SplitN(m.Name, ":", 2)[0],
+		"general.file_type":                     15,
+		"general.parameter_count":               m.Size / 2 * 3,
+		"general.quantization_version":          2,
+		"general.type":                          "model",
+		a + ".attention.head_count":             heads,
+		a + ".attention.head_count_kv":          8,
+		a + ".attention.layer_norm_rms_epsilon": 1e-05,
+		a + ".block_count":                      m.blocks,
+		a + ".context_length":                   m.Details.ContextLength,
+		a + ".embedding_length":                 m.Details.EmbeddingLength,
+		a + ".feed_forward_length":              m.Details.EmbeddingLength * 4,
+		a + ".rope.dimension_count":             128,
+		a + ".rope.freq_base":                   500000,
+		a + ".vocab_size":                       128256,
+		"tokenizer.ggml.bos_token_id":           128000,
+		"tokenizer.ggml.eos_token_id":           128009,
+		"tokenizer.ggml.model":                  "gpt2",
+		"tokenizer.ggml.pre":                    a,
+	}
+}
+
+// tensorList synthesises the per-layer tensor inventory /api/show reports, following the GGUF
+// naming convention (token_embd, output_norm, blk.N.*).
+func tensorList(m CatalogModel) []tensor {
+	embd := m.Details.EmbeddingLength
+	if embd == 0 {
+		embd = 4096
+	}
+	ffn := embd * 4
+	out := []tensor{
+		{Name: "output_norm.weight", Type: "F32", Shape: []int{embd}},
+		{Name: "token_embd.weight", Type: "Q6_K", Shape: []int{embd, 128256}},
+	}
+	for i := 0; i < m.blocks; i++ {
+		p := fmt.Sprintf("blk.%d.", i)
+		out = append(out,
+			tensor{Name: p + "attn_norm.weight", Type: "F32", Shape: []int{embd}},
+			tensor{Name: p + "attn_q.weight", Type: "Q4_K", Shape: []int{embd, embd}},
+			tensor{Name: p + "attn_k.weight", Type: "Q4_K", Shape: []int{embd, embd / 4}},
+			tensor{Name: p + "attn_v.weight", Type: "Q6_K", Shape: []int{embd, embd / 4}},
+			tensor{Name: p + "attn_output.weight", Type: "Q4_K", Shape: []int{embd, embd}},
+			tensor{Name: p + "ffn_norm.weight", Type: "F32", Shape: []int{embd}},
+			tensor{Name: p + "ffn_gate.weight", Type: "Q4_K", Shape: []int{embd, ffn}},
+			tensor{Name: p + "ffn_up.weight", Type: "Q4_K", Shape: []int{embd, ffn}},
+			tensor{Name: p + "ffn_down.weight", Type: "Q6_K", Shape: []int{ffn, embd}},
+		)
+	}
+	return out
+}
+
+func handleShow(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	if err := readJSON(r, &req); err != nil {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.model() == "" {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, "model is required")
+		return
+	}
+	m, ok := models.get(req.model())
+	if !ok {
+		llmcore.WriteModelNotFoundAPI(w, profile, normalize(req.model()))
+		return
+	}
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, showResponse{
+		License: "MIT License\n\nPermission is hereby granted, free of charge, to any person " +
+			"obtaining a copy of this software and associated documentation files.",
+		Modelfile: fmt.Sprintf("# Modelfile generated by \"ollama show\"\n"+
+			"# To build a new Modelfile based on this, replace FROM with:\n"+
+			"# FROM %s\n\nFROM /root/.ollama/models/blobs/sha256-%s\nTEMPLATE \"\"\"{{ .System }}{{ .Prompt }}\"\"\"",
+			m.Name, m.Digest),
+		Parameters:   "stop                           \"<|start_header_id|>\"\nstop                           \"<|end_header_id|>\"\nstop                           \"<|eot_id|>\"",
+		Template:     "{{ if .System }}<|start_header_id|>system<|end_header_id|>\n\n{{ .System }}<|eot_id|>{{ end }}{{ if .Prompt }}<|start_header_id|>user<|end_header_id|>\n\n{{ .Prompt }}<|eot_id|>{{ end }}<|start_header_id|>assistant<|end_header_id|>\n\n",
+		Details:      m.Details,
+		ModelInfo:    modelInfo(m),
+		Tensors:      tensorList(m),
+		Capabilities: m.Capabilities,
+		ModifiedAt:   m.ModifiedAt,
+	})
+}
+
+// -- /api/pull
+
+type pullStatus struct {
+	Status    string `json:"status"`
+	Digest    string `json:"digest,omitempty"`
+	Total     int64  `json:"total,omitempty"`
+	Completed int64  `json:"completed,omitempty"`
+}
+
+// pullLayers is how many blob layers a pull reports before finishing.
+const pullLayers = 3
+
+// pullStepDelay paces the fake download. Overridden to zero in tests so the suite does not spend
+// seconds waiting on deliberately-slow output.
+var pullStepDelay = func() time.Duration {
+	return time.Duration(120+rand.Intn(180)) * time.Millisecond
+}
+
+// handlePull streams a convincing model download. This is a deliberate divergence from the real
+// server, which actually fetches from a registry: we stream plausible progress and then add the
+// model to this instance's catalog, so an attacker who pulls a model finds it in /api/tags and
+// goes on to use it — and that follow-up traffic is the payload worth capturing.
+//
+// Progress is paced over a few seconds rather than the minutes a real multi-GB pull takes: long
+// enough not to look instantaneous, short enough that concurrent pulls cannot tie the honeypot
+// up. The pacing aborts as soon as the client disconnects.
+func handlePull(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	if err := readJSON(r, &req); err != nil {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, err.Error())
+		return
+	}
+	name := req.model()
+	if name == "" {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, "model is required")
+		return
+	}
+
+	w.Header().Set("Content-Type", llmcore.CTNDJSON)
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	ctx := r.Context()
+	emit := func(v pullStatus) bool {
+		b, _ := json.Marshal(v)
+		if _, err := fmt.Fprintf(w, "%s\n", b); err != nil {
+			return false
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return ctx.Err() == nil
+	}
+
+	if !emit(pullStatus{Status: "pulling manifest"}) {
+		return
+	}
+
+	target := synthesize(name)
+	remaining := target.Size
+	for layer := 0; layer < pullLayers && remaining > 0; layer++ {
+		digest := pseudoDigest(fmt.Sprintf("%s/layer/%d", normalize(name), layer))
+		size := remaining
+		if layer < pullLayers-1 {
+			size = remaining / 2
+		}
+		remaining -= size
+		short := digest[:12]
+		steps := 6 + rand.Intn(5)
+		for s := 1; s <= steps; s++ {
+			done := size * int64(s) / int64(steps)
+			if !emit(pullStatus{
+				Status: "pulling " + short, Digest: "sha256:" + digest,
+				Total: size, Completed: done,
+			}) {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(pullStepDelay()):
+			}
+		}
+	}
+
+	for _, s := range []string{"verifying sha256 digest", "writing manifest", "success"} {
+		if !emit(pullStatus{Status: s}) {
+			return
+		}
+	}
+	models.add(target)
+}
+
+// -- /api/push, /api/create
+
+// handlePush mirrors the real failure path: an unauthenticated box has no registry credentials,
+// so a push gets as far as the manifest lookup and stops.
+func handlePush(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	_ = readJSON(r, &req)
+	w.Header().Set("Content-Type", llmcore.CTNDJSON)
+	w.WriteHeader(http.StatusOK)
+	writeLine(w, map[string]string{"status": "retrieving manifest"})
+	writeLine(w, map[string]string{"status": "couldn't retrieve manifest"})
+	writeLine(w, map[string]string{
+		"error": fmt.Sprintf("open /root/.ollama/models/manifests/registry.ollama.ai/%s: no such file or directory",
+			strings.ReplaceAll(normalize(req.model()), ":", "/")),
+	})
+}
+
+// handleCreate answers the way a real server does when the FROM model is not present locally:
+// it starts pulling the base layer and fails on the manifest.
+func handleCreate(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Model string `json:"model"`
+		Name  string `json:"name"`
+		From  string `json:"from"`
+	}
+	_ = readJSON(r, &req)
+	w.Header().Set("Content-Type", llmcore.CTNDJSON)
+	w.WriteHeader(http.StatusOK)
+	if req.From != "" && models.has(req.From) {
+		for _, s := range []string{"using existing layer", "creating new layer", "writing manifest", "success"} {
+			writeLine(w, map[string]string{"status": s})
+		}
+		return
+	}
+	writeLine(w, map[string]string{"status": "pulling manifest"})
+	writeLine(w, map[string]string{"error": "pull model manifest: file does not exist"})
+}
+
+func writeLine(w http.ResponseWriter, v any) {
+	b, _ := json.Marshal(v)
+	fmt.Fprintf(w, "%s\n", b)
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// -- /api/copy, /api/delete
+
+func handleCopy(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	if err := readJSON(r, &req); err != nil {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, err.Error())
+		return
+	}
+	src, ok := models.get(req.Source)
+	if !ok {
+		// Note the escaped-quote form here: real Ollama uses %q for copy but '%s' for show.
+		llmcore.WriteOllamaError(w, profile, http.StatusNotFound,
+			fmt.Sprintf("model %q not found", req.Source))
+		return
+	}
+	if req.Dest != "" {
+		copied := src
+		copied.Name = normalize(req.Dest)
+		copied.Model = copied.Name
+		copied.ModifiedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		models.add(copied)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleDelete(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	if err := readJSON(r, &req); err != nil {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, err.Error())
+		return
+	}
+	if !models.remove(req.model()) {
+		llmcore.WriteModelNotFoundAPI(w, profile, normalize(req.model()))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// -- /api/blobs
+
+var digestRe = regexp.MustCompile(`^sha256[:-][a-f0-9]{64}$`)
+
+func handleBlob(w http.ResponseWriter, r *http.Request) {
+	digest := mux.Vars(r)["digest"]
+	if !digestRe.MatchString(digest) {
+		llmcore.WriteOllamaError(w, profile, http.StatusBadRequest, "invalid digest format")
+		return
+	}
+	// A blob the server does not hold: real Ollama 404s HEAD and accepts POST uploads.
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+// -- embeddings
+
+// handleEmbedAPI and handleEmbedV1 report the 501 a real server returns for a model without
+// embedding support, which is true of every model in the advertised catalog. Inventing a
+// plausible float vector would be both more work and less accurate than the genuine refusal.
+func handleEmbedAPI(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	_ = readJSON(r, &req)
+	if req.model() != "" && !models.has(req.model()) {
+		llmcore.WriteOllamaError(w, profile, http.StatusNotFound,
+			fmt.Sprintf("model %q not found, try pulling it first", req.model()))
+		return
+	}
+	llmcore.WriteEmbeddingsUnsupported(w, profile, false)
+}
+
+func handleEmbedV1(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	_ = readJSON(r, &req)
+	if req.model() != "" && !models.has(req.model()) {
+		llmcore.WriteOpenAIError(w, profile, http.StatusNotFound,
+			fmt.Sprintf("model %q not found, try pulling it first", req.model()), "not_found_error")
+		return
+	}
+	llmcore.WriteEmbeddingsUnsupported(w, profile, true)
+}
+
+// -- /v1/responses
+
+func handleResponses(w http.ResponseWriter, r *http.Request) {
+	llmcore.Responses(w, r, profile)
+}

--- a/ollama/ollama.go
+++ b/ollama/ollama.go
@@ -1,9 +1,20 @@
+// Package ollama emulates an exposed, unauthenticated Ollama server (default port 11434) —
+// the port internet scanners hunt for reachable LLM inference, and by volume the busiest of
+// the LLM-infra honeypots.
+//
+// Behaviour is matched against a real Ollama 0.30.11: Ollama is built on Gin, so it emits no
+// Server header, answers unrouted paths with Gin's plain-text "404 page not found", and appends
+// "; charset=utf-8" to its /api/* JSON content type while its OpenAI-compat /v1/* layer does
+// not. Divergences from the real server are deliberate and commented.
 package ollama
 
 import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/joshrendek/threat.gg-agent/cmdresp"
@@ -16,10 +27,25 @@ import (
 const (
 	defaultPort  = "11434"
 	defaultModel = "llama3.2:latest"
+	// version is advertised by /api/version. It has to stay consistent with the feature surface
+	// below: /v1/responses, capabilities[] and details.context_length only exist on modern
+	// Ollama, so claiming an old 0.3.x here would be an impossible combination.
+	version  = "0.30.11"
+	rootBody = "Ollama is running"
 )
 
 var _ honeypots.Honeypot = &honeypot{}
 var saveOllamaRequest = persistence.SaveOllamaRequest
+
+// profile describes Ollama's OpenAI-compat surface: short completion ids, an "fp_ollama"
+// system fingerprint, and a catalog that makes unknown models 404 the way a real box does.
+var profile = llmcore.Profile{
+	DefaultModel:      defaultModel,
+	ContentType:       llmcore.CTJSONCharset,
+	SystemFingerprint: "fp_ollama",
+	ShortIDs:          true,
+	KnownModel:        func(m string) bool { return models.has(m) },
+}
 
 type honeypot struct{ logger zerolog.Logger }
 
@@ -38,94 +64,221 @@ func (h *honeypot) Start() {
 	h.logger.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%s", port), buildHandler())).Msg("failed to start")
 }
 
-// buildHandler composes the full chain; identityHeaders wraps cmdresp so the Server
-// header is stamped even when an authored override short-circuits the router.
+// buildHandler composes the full chain. corsHeaders wraps cmdresp so CORS is applied even when
+// an admin-authored override short-circuits the router (the jenkins ordering pattern). Note
+// there is deliberately no Server header: real Ollama sends none, so stamping one would be a
+// positive honeypot signature rather than a missing detail.
 func buildHandler() http.Handler {
-	return llmcore.Capture(saveOllamaRequest)(identityHeaders(cmdresp.MuxMiddleware("ollama")(newRouter())))
+	return llmcore.Capture(saveOllamaRequest)(corsHeaders(cmdresp.MuxMiddleware("ollama")(newRouter())))
 }
 
-func identityHeaders(next http.Handler) http.Handler {
+// corsAllowHeaders is the exact allow-list a modern Ollama echoes on a preflight, including the
+// OpenAI SDK's X-Stainless-* telemetry headers. The list is distinctive enough to fingerprint
+// on, so it is reproduced verbatim rather than approximated.
+const corsAllowHeaders = "Authorization,Content-Type,User-Agent,Accept,X-Requested-With," +
+	"Openai-Beta,X-Stainless-Arch,X-Stainless-Async,X-Stainless-Custom-Poll-Interval," +
+	"X-Stainless-Helper-Method,X-Stainless-Lang,X-Stainless-Os,X-Stainless-Package-Version," +
+	"X-Stainless-Poll-Helper,X-Stainless-Retry-Count,X-Stainless-Runtime," +
+	"X-Stainless-Runtime-Version,X-Stainless-Timeout"
+
+// corsHeaders emulates a box started with OLLAMA_ORIGINS=*. That is both what a machine
+// deliberately exposed to the internet typically runs (it is usually exposed so some web UI can
+// reach it) and the more inviting configuration: the default origin policy 403s any
+// browser-originated probe before it ever reaches a handler.
+func corsHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Server", "Ollama")
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
+			w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS")
+			w.Header().Set("Access-Control-Max-Age", "43200")
+			if allowed := allowedMethods(r.URL.Path); allowed != "" {
+				w.Header().Set("Allow", allowed)
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		next.ServeHTTP(w, r)
 	})
 }
 
+// routeMethods records which methods each route accepts, so 405s can carry the Allow header Gin
+// sets and preflights can answer accurately.
+var routeMethods = map[string]string{
+	"/":                    "HEAD, GET",
+	"/api/tags":            "HEAD, GET",
+	"/api/version":         "HEAD, GET",
+	"/api/ps":              "HEAD, GET",
+	"/api/generate":        "POST",
+	"/api/chat":            "POST",
+	"/api/show":            "POST",
+	"/api/pull":            "POST",
+	"/api/push":            "POST",
+	"/api/create":          "POST",
+	"/api/copy":            "POST",
+	"/api/delete":          "DELETE",
+	"/api/embed":           "POST",
+	"/api/embeddings":      "POST",
+	"/v1/models":           "HEAD, GET",
+	"/v1/chat/completions": "POST",
+	"/v1/completions":      "POST",
+	"/v1/responses":        "POST",
+	"/v1/embeddings":       "POST",
+}
+
+func allowedMethods(path string) string {
+	p := path
+	if p != "/" {
+		p = strings.TrimSuffix(p, "/")
+	}
+	if m, ok := routeMethods[p]; ok {
+		return m
+	}
+	if strings.HasPrefix(p, "/api/blobs/") {
+		return "HEAD, POST"
+	}
+	return ""
+}
+
 func newRouter() http.Handler {
 	r := mux.NewRouter()
-	r.HandleFunc("/", handleRoot).Methods("GET")
-	r.HandleFunc("/api/tags", handleTags).Methods("GET")
-	r.HandleFunc("/api/version", handleVersion).Methods("GET")
-	r.HandleFunc("/api/ps", handlePs).Methods("GET")
+	// Gin matches HEAD on routes registered for GET; gorilla/mux does not, so HEAD is listed
+	// explicitly. Without it, HEAD / fell through to the 404 handler while a real Ollama
+	// answers 200 — a one-request tell.
+	get := []string{http.MethodGet, http.MethodHead}
+
+	r.HandleFunc("/", handleRoot).Methods(get...)
+	r.HandleFunc("/api/tags", handleTags).Methods(get...)
+	r.HandleFunc("/api/version", handleVersion).Methods(get...)
+	r.HandleFunc("/api/ps", handlePs).Methods(get...)
 	r.HandleFunc("/api/generate", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.OllamaGenerate(w, req, defaultModel)
-	}).Methods("POST")
+		llmcore.OllamaGenerate(w, req, profile)
+	}).Methods(http.MethodPost)
 	r.HandleFunc("/api/chat", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.OllamaChat(w, req, defaultModel)
-	}).Methods("POST")
-	r.HandleFunc("/api/show", handleShow).Methods("POST")
-	// OpenAI-compatible aliases
-	r.HandleFunc("/v1/models", handleV1Models).Methods("GET")
+		llmcore.OllamaChat(w, req, profile)
+	}).Methods(http.MethodPost)
+	r.HandleFunc("/api/show", handleShow).Methods(http.MethodPost)
+	r.HandleFunc("/api/pull", handlePull).Methods(http.MethodPost)
+	r.HandleFunc("/api/push", handlePush).Methods(http.MethodPost)
+	r.HandleFunc("/api/create", handleCreate).Methods(http.MethodPost)
+	r.HandleFunc("/api/copy", handleCopy).Methods(http.MethodPost)
+	r.HandleFunc("/api/delete", handleDelete).Methods(http.MethodDelete)
+	r.HandleFunc("/api/embed", handleEmbedAPI).Methods(http.MethodPost)
+	r.HandleFunc("/api/embeddings", handleEmbedAPI).Methods(http.MethodPost)
+	r.HandleFunc("/api/blobs/{digest}", handleBlob).Methods(http.MethodHead, http.MethodPost)
+
+	// OpenAI-compatible layer. These answer with bare application/json (no charset) because
+	// inside Ollama they are served by a different handler chain than the /api/* routes.
+	r.HandleFunc("/v1/models", handleV1Models).Methods(get...)
 	r.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.ChatCompletion(w, req, defaultModel)
-	}).Methods("POST")
-	r.PathPrefix("/").HandlerFunc(handleCatchAll)
+		llmcore.ChatCompletion(w, req, profile)
+	}).Methods(http.MethodPost)
+	r.HandleFunc("/v1/completions", func(w http.ResponseWriter, req *http.Request) {
+		llmcore.Completion(w, req, profile)
+	}).Methods(http.MethodPost)
+	r.HandleFunc("/v1/responses", handleResponses).Methods(http.MethodPost)
+	r.HandleFunc("/v1/embeddings", handleEmbedV1).Methods(http.MethodPost)
+
+	r.NotFoundHandler = http.HandlerFunc(handleNotFound)
+	r.MethodNotAllowedHandler = http.HandlerFunc(handleMethodNotAllowed)
 	return r
 }
 
+// handleNotFound reproduces Gin's default 404: plain text, no charset parameter, no JSON body.
+func handleNotFound(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", llmcore.CTText)
+	w.WriteHeader(http.StatusNotFound)
+	fmt.Fprint(w, "404 page not found")
+}
+
+// handleMethodNotAllowed reproduces Gin's 405, including the Allow header listing the methods
+// the route does accept.
+func handleMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
+	if allowed := allowedMethods(r.URL.Path); allowed != "" {
+		w.Header().Set("Allow", allowed)
+	}
+	w.Header().Set("Content-Type", llmcore.CTText)
+	w.WriteHeader(http.StatusMethodNotAllowed)
+	fmt.Fprint(w, "405 method not allowed")
+}
+
 func handleRoot(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Type", llmcore.CTTextCharset)
+	w.Header().Set("Content-Length", fmt.Sprint(len(rootBody)))
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprint(w, "Ollama is running")
+	if r.Method == http.MethodHead {
+		return
+	}
+	fmt.Fprint(w, rootBody)
+}
+
+type tagsResponse struct {
+	Models []CatalogModel `json:"models"`
 }
 
 func handleTags(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
-		"models": []map[string]any{
-			{
-				"name": "llama3.2:latest", "model": "llama3.2:latest",
-				"modified_at": "2026-06-01T12:00:00Z", "size": int64(2019393189),
-				"digest":  "a80c4f17acd55265feb1f6c8f10a0b2b6b6c7f8a9b0c1d2e3f4a5b6c7d8e9f0a1",
-				"details": map[string]any{"family": "llama", "parameter_size": "3.2B", "quantization_level": "Q4_K_M"},
-			},
-			{
-				"name": "mistral:latest", "model": "mistral:latest",
-				"modified_at": "2026-05-15T09:30:00Z", "size": int64(4113301824),
-				"digest":  "61e88e884507ba5e06c49b40e6226884b2a16e872382c2b44a42f2d119d804a5",
-				"details": map[string]any{"family": "llama", "parameter_size": "7B", "quantization_level": "Q4_0"},
-			},
-		},
-	})
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, tagsResponse{Models: models.list()})
+}
+
+type versionResponse struct {
+	Version string `json:"version"`
 }
 
 func handleVersion(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{"version": "0.3.12"})
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, versionResponse{Version: version})
 }
 
+type psModel struct {
+	Name      string  `json:"name"`
+	Model     string  `json:"model"`
+	Size      int64   `json:"size"`
+	Digest    string  `json:"digest"`
+	Details   Details `json:"details"`
+	ExpiresAt string  `json:"expires_at"`
+	SizeVRAM  int64   `json:"size_vram"`
+}
+
+type psResponse struct {
+	Models []psModel `json:"models"`
+}
+
+// handlePs lists the models currently resident. Because llmcore already tracks residency for its
+// timing model, an attacker who runs a completion and then checks /api/ps sees the model they
+// just used listed as loaded — and sees it fall off once keep_alive expires, like a real server.
 func handlePs(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{"models": []any{}})
+	out := []psModel{}
+	for name, expires := range llmcore.ResidentModels() {
+		m, ok := models.get(name)
+		if !ok {
+			continue
+		}
+		out = append(out, psModel{
+			Name: m.Name, Model: m.Model, Size: m.Size, Digest: m.Digest,
+			Details:   m.Details,
+			ExpiresAt: expires.UTC().Format(time.RFC3339Nano),
+			SizeVRAM:  m.Size,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, psResponse{Models: out})
 }
 
-func handleShow(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
-		"license":    "MIT",
-		"modelfile":  "# Modelfile generated by \"ollama show\"\nFROM llama3.2",
-		"parameters": "stop \"<|start_header_id|>\"",
-		"template":   "{{ .System }}{{ .Prompt }}",
-		"details":    map[string]any{"family": "llama", "parameter_size": "3.2B", "quantization_level": "Q4_K_M"},
-	})
+type v1ModelsResponse struct {
+	Object string          `json:"object"`
+	Data   []llmcore.Model `json:"data"`
 }
 
 func handleV1Models(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
-		"object": "list",
-		"data": []map[string]any{
-			{"id": "llama3.2:latest", "object": "model", "created": 1735689600, "owned_by": "library"},
-			{"id": "mistral:latest", "object": "model", "created": 1735689600, "owned_by": "library"},
-		},
-	})
-}
-
-func handleCatchAll(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusNotFound, map[string]any{"error": "not found"})
+	list := models.list()
+	data := make([]llmcore.Model, 0, len(list))
+	for _, m := range list {
+		created, err := time.Parse(time.RFC3339Nano, m.ModifiedAt)
+		if err != nil {
+			created = time.Now()
+		}
+		data = append(data, llmcore.Model{
+			ID: m.Name, Object: "model", Created: created.Unix(), OwnedBy: "library",
+		})
+	}
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, v1ModelsResponse{Object: "list", Data: data})
 }

--- a/ollama/ollama_test.go
+++ b/ollama/ollama_test.go
@@ -54,7 +54,15 @@ func TestGenerateNonStreamAndOpenAIAlias(t *testing.T) {
 	}
 }
 
-func TestServerHeaderSurvivesCmdrespOverride(t *testing.T) {
+// TestCORSSurvivesCmdrespOverride pins the middleware ordering: an admin-authored cmdresp
+// override short-circuits the router, and the identity middleware must still have run.
+//
+// This test previously asserted the opposite of what it does now — it required a
+// "Server: Ollama" header. That header was the single worst fingerprint on the honeypot: real
+// Ollama is built on Gin and sends no Server header at all, so emitting one was a positive
+// honeypot signature rather than a missing detail. The ordering guarantee is still worth
+// pinning, so the assertion now rides on the CORS header, which real Ollama does send.
+func TestCORSSurvivesCmdrespOverride(t *testing.T) {
 	orig := cmdresp.GetCommandResponse
 	cmdresp.GetCommandResponse = func(*proto.CommandRequest) (*proto.CommandResponse, error) {
 		return &proto.CommandResponse{Response: `{"overridden":true}`, Matched: true}, nil
@@ -65,7 +73,10 @@ func TestServerHeaderSurvivesCmdrespOverride(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), "overridden") {
 		t.Fatalf("expected override body, got %s", rec.Body.String())
 	}
-	if got := rec.Header().Get("Server"); !strings.Contains(got, "Ollama") {
-		t.Fatalf("Server header lost on cmdresp override: %q", got)
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("CORS header lost on cmdresp override: %q", got)
+	}
+	if got := rec.Header().Get("Server"); got != "" {
+		t.Fatalf("Server header must never be set (real Ollama sends none), got %q", got)
 	}
 }

--- a/ollama/reference_diff_test.go
+++ b/ollama/reference_diff_test.go
@@ -1,0 +1,119 @@
+package ollama
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAgainstReferenceServer diffs this honeypot against a real Ollama, so the fidelity claims
+// in PRD 033 can be re-verified against a new upstream release rather than trusted forever.
+//
+// Skipped unless a reference server is pointed at:
+//
+//	OLLAMA_REFERENCE_URL=http://127.0.0.1:11434 go test ./ollama/ -run Reference -v
+//
+// It compares the observable properties a fingerprinting scanner can read without knowing which
+// models the box happens to host: status code, content type, and the presence or absence of
+// identifying headers. Body *values* legitimately differ (a real box lists its own models); body
+// *shape* is covered by the fixtures in fidelity_test.go.
+func TestAgainstReferenceServer(t *testing.T) {
+	ref := os.Getenv("OLLAMA_REFERENCE_URL")
+	if ref == "" {
+		t.Skip("set OLLAMA_REFERENCE_URL to a real Ollama to run the reference diff")
+	}
+	ref = strings.TrimRight(ref, "/")
+
+	srv := httptest.NewServer(buildHandler())
+	defer srv.Close()
+
+	cases := []struct {
+		name, method, path, body string
+		// unknownModel marks requests naming a model the reference box will not have either,
+		// so both sides should produce the same not-found behaviour.
+		unknownModel bool
+	}{
+		{name: "root", method: "GET", path: "/"},
+		{name: "head root", method: "HEAD", path: "/"},
+		{name: "version", method: "GET", path: "/api/version"},
+		{name: "tags", method: "GET", path: "/api/tags"},
+		{name: "ps", method: "GET", path: "/api/ps"},
+		{name: "v1 models", method: "GET", path: "/v1/models"},
+		{name: "404 props", method: "GET", path: "/props"},
+		{name: "404 metrics", method: "GET", path: "/metrics"},
+		{name: "404 random", method: "GET", path: "/nonexistent-xyz"},
+		{name: "405 generate", method: "GET", path: "/api/generate"},
+		{name: "show no model", method: "POST", path: "/api/show", body: `{}`},
+		{name: "show unknown", method: "POST", path: "/api/show", body: `{"name":"nope:latest"}`, unknownModel: true},
+		{name: "chat unknown model", method: "POST", path: "/api/chat",
+			body: `{"model":"nope:latest","messages":[{"role":"user","content":"hi"}],"stream":false}`, unknownModel: true},
+		{name: "v1 chat unknown model", method: "POST", path: "/v1/chat/completions",
+			body: `{"model":"nope","messages":[{"role":"user","content":"hi"}]}`, unknownModel: true},
+		{name: "generate malformed", method: "POST", path: "/api/generate", body: `not-json`},
+		{name: "delete unknown", method: "DELETE", path: "/api/delete", body: `{"name":"nope:latest"}`, unknownModel: true},
+		{name: "blob bad digest", method: "HEAD", path: "/api/blobs/sha256:0000"},
+	}
+
+	fetch := func(base string, c struct {
+		name, method, path, body string
+		unknownModel             bool
+	}) (*http.Response, []byte, error) {
+		var rdr io.Reader
+		if c.body != "" {
+			rdr = strings.NewReader(c.body)
+		}
+		req, err := http.NewRequest(c.method, base+c.path, rdr)
+		if err != nil {
+			return nil, nil, err
+		}
+		if c.body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, nil, err
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		return resp, b, nil
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			realResp, realBody, err := fetch(ref, c)
+			if err != nil {
+				t.Fatalf("reference request failed: %v", err)
+			}
+			ourResp, ourBody, err := fetch(srv.URL, c)
+			if err != nil {
+				t.Fatalf("honeypot request failed: %v", err)
+			}
+
+			if realResp.StatusCode != ourResp.StatusCode {
+				t.Errorf("status: honeypot %d, real %d", ourResp.StatusCode, realResp.StatusCode)
+			}
+			if r, o := realResp.Header.Get("Content-Type"), ourResp.Header.Get("Content-Type"); r != o {
+				t.Errorf("content-type: honeypot %q, real %q", o, r)
+			}
+			if r, o := realResp.Header.Get("Server"), ourResp.Header.Get("Server"); r != o {
+				t.Errorf("Server header: honeypot %q, real %q", o, r)
+			}
+			if r, o := realResp.Header.Get("Allow"), ourResp.Header.Get("Allow"); r != o {
+				t.Errorf("Allow header: honeypot %q, real %q", o, r)
+			}
+			// For plain-text and not-found paths the bodies should match exactly; for
+			// catalog-dependent endpoints they legitimately differ.
+			if c.unknownModel || strings.HasPrefix(c.name, "404") || strings.HasPrefix(c.name, "405") ||
+				c.name == "root" || c.name == "show no model" || c.name == "blob bad digest" {
+				if !bytes.Equal(bytes.TrimSpace(realBody), bytes.TrimSpace(ourBody)) {
+					t.Errorf("body mismatch:\n honeypot: %s\n real:     %s", ourBody, realBody)
+				}
+			}
+		})
+	}
+}

--- a/vllm/docs.go
+++ b/vllm/docs.go
@@ -1,0 +1,112 @@
+package vllm
+
+// FastAPI mounts Swagger UI at /docs and the schema at /openapi.json by default, and vLLM does
+// not disable them. A box that answers /v1/models and /metrics like FastAPI but 404s both of
+// these is inconsistent with any real deployment.
+
+const swaggerHTML = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <link type="text/css" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
+    <link rel="shortcut icon" href="https://fastapi.tiangolo.com/img/favicon.png">
+    <title>vLLM API - Swagger UI</title>
+    </head>
+    <body>
+    <div id="swagger-ui">
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+    <!-- ` + "`SwaggerUIBundle` is now available on the page" + ` -->
+    <script>
+    const ui = SwaggerUIBundle({
+        url: '/openapi.json',
+    "dom_id": "#swagger-ui",
+"layout": "BaseLayout",
+"deepLinking": true,
+"showExtensions": true,
+"showCommonExtensions": true,
+oauth2RedirectUrl: window.location.origin + '/docs/oauth2-redirect',
+    presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+        ],
+    })
+    </script>
+    </body>
+    </html>
+    `
+
+// openAPISchema returns a structurally faithful, abbreviated FastAPI schema for the routes this
+// honeypot serves. Endpoint list and shapes match; the component schemas are trimmed.
+func openAPISchema() map[string]any {
+	post := func(id, summary string) map[string]any {
+		return map[string]any{
+			"post": map[string]any{
+				"summary":     summary,
+				"operationId": id,
+				"responses": map[string]any{
+					"200": map[string]any{
+						"description": "Successful Response",
+						"content":     map[string]any{"application/json": map[string]any{"schema": map[string]any{}}},
+					},
+					"422": map[string]any{
+						"description": "Validation Error",
+						"content": map[string]any{"application/json": map[string]any{
+							"schema": map[string]any{"$ref": "#/components/schemas/HTTPValidationError"},
+						}},
+					},
+				},
+			},
+		}
+	}
+	get := func(id, summary string) map[string]any {
+		return map[string]any{
+			"get": map[string]any{
+				"summary":     summary,
+				"operationId": id,
+				"responses": map[string]any{
+					"200": map[string]any{
+						"description": "Successful Response",
+						"content":     map[string]any{"application/json": map[string]any{"schema": map[string]any{}}},
+					},
+				},
+			},
+		}
+	}
+	return map[string]any{
+		"openapi": "3.1.0",
+		"info":    map[string]any{"title": "vLLM API", "version": vllmVersion},
+		"paths": map[string]any{
+			"/health":              get("health_health_get", "Health"),
+			"/ping":                get("ping_ping_get", "Ping"),
+			"/version":             get("show_version_version_get", "Show Version"),
+			"/tokenize":            post("tokenize_tokenize_post", "Tokenize"),
+			"/detokenize":          post("detokenize_detokenize_post", "Detokenize"),
+			"/v1/models":           get("show_available_models_v1_models_get", "Show Available Models"),
+			"/v1/chat/completions": post("create_chat_completion_v1_chat_completions_post", "Create Chat Completion"),
+			"/v1/completions":      post("create_completion_v1_completions_post", "Create Completion"),
+			"/v1/embeddings":       post("create_embedding_v1_embeddings_post", "Create Embedding"),
+		},
+		"components": map[string]any{
+			"schemas": map[string]any{
+				"HTTPValidationError": map[string]any{
+					"properties": map[string]any{
+						"detail": map[string]any{
+							"items": map[string]any{"$ref": "#/components/schemas/ValidationError"},
+							"type":  "array", "title": "Detail",
+						},
+					},
+					"type": "object", "title": "HTTPValidationError",
+				},
+				"ValidationError": map[string]any{
+					"properties": map[string]any{
+						"loc":  map[string]any{"items": map[string]any{}, "type": "array", "title": "Location"},
+						"msg":  map[string]any{"type": "string", "title": "Message"},
+						"type": map[string]any{"type": "string", "title": "Error Type"},
+					},
+					"type": "object", "required": []string{"loc", "msg", "type"}, "title": "ValidationError",
+				},
+			},
+		},
+	}
+}

--- a/vllm/fidelity_test.go
+++ b/vllm/fidelity_test.go
@@ -1,0 +1,132 @@
+package vllm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for PRD 033. vLLM runs on FastAPI behind uvicorn, so its wire behaviour
+// differs from Ollama's in specific, checkable ways.
+
+func do(t *testing.T, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	rec := httptest.NewRecorder()
+	buildHandler().ServeHTTP(rec, r)
+	return rec
+}
+
+// /metrics is the single most-requested path on this honeypot in prod (16 hits, 11 distinct
+// IPs — Palo Alto Xpanse and similar) and used to return a JSON 404.
+func TestMetricsServesPrometheusText(t *testing.T) {
+	rec := do(t, "GET", "/metrics", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/plain; version=0.0.4") {
+		t.Errorf("content-type %q, want Prometheus exposition", got)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"# HELP vllm:num_requests_running",
+		"# TYPE vllm:num_requests_running gauge",
+		"vllm:prompt_tokens_total",
+		"vllm:generation_tokens_total",
+		"vllm:time_to_first_token_seconds_bucket",
+		"vllm:e2e_request_latency_seconds_sum",
+		"vllm:cache_config_info",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics missing %q", want)
+		}
+	}
+	if !strings.Contains(body, `model_name="`+defaultModel+`"`) {
+		t.Error("metrics not labelled with the served model")
+	}
+}
+
+// A real exporter's counters advance between scrapes; a frozen body is its own tell.
+func TestMetricsCountersAdvance(t *testing.T) {
+	first := do(t, "GET", "/metrics", "").Body.String()
+	// counterAt is derived from uptime, so a later scrape must not be byte-identical forever.
+	// Assert the mechanism rather than sleeping: the counter must be non-zero and parseable.
+	if !strings.Contains(first, "vllm:prompt_tokens_total{") {
+		t.Fatal("prompt tokens counter missing")
+	}
+	if strings.Contains(first, "vllm:prompt_tokens_total{model_name=\""+defaultModel+"\"} 0\n") {
+		t.Error("counter is pinned at zero; a box serving traffic would have accrued tokens")
+	}
+}
+
+// FastAPI answers unrouted paths with {"detail":"Not Found"} — not an OpenAI error envelope.
+func TestNotFoundIsFastAPIShape(t *testing.T) {
+	rec := do(t, "GET", "/definitely-not-a-route", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"detail":"Not Found"}` {
+		t.Errorf("body %q, want %q", got, `{"detail":"Not Found"}`)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type %q, want bare application/json (FastAPI adds no charset)", got)
+	}
+}
+
+// uvicorn genuinely does send a Server header, unlike Ollama's Gin.
+func TestUvicornServerHeaderIsPresent(t *testing.T) {
+	if got := do(t, "GET", "/health", "").Header().Get("Server"); got != "uvicorn" {
+		t.Errorf("Server %q, want uvicorn", got)
+	}
+}
+
+// FastAPI mounts these by default and vLLM does not disable them; 404ing both on a box that is
+// otherwise obviously FastAPI is inconsistent.
+func TestOpenAPIAndDocsAreMounted(t *testing.T) {
+	rec := do(t, "GET", "/openapi.json", "")
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"openapi"`) {
+		t.Errorf("/openapi.json: status %d body %.80s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "/v1/chat/completions") {
+		t.Error("/openapi.json does not document the served routes")
+	}
+	rec = do(t, "GET", "/docs", "")
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "swagger-ui") {
+		t.Errorf("/docs: status %d", rec.Code)
+	}
+}
+
+// vLLM omits system_fingerprint entirely, where Ollama stamps "fp_ollama". Emitting Ollama's
+// value here would be a cross-product inconsistency.
+func TestNoSystemFingerprint(t *testing.T) {
+	rec := do(t, "POST", "/v1/chat/completions",
+		`{"model":"`+defaultModel+`","messages":[{"role":"user","content":"hi"}]}`)
+	if strings.Contains(rec.Body.String(), "system_fingerprint") {
+		t.Errorf("vLLM must not emit system_fingerprint: %s", rec.Body.String())
+	}
+}
+
+func TestTokenizeAndPing(t *testing.T) {
+	rec := do(t, "POST", "/tokenize", `{"prompt":"hello world"}`)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"count"`) {
+		t.Errorf("/tokenize: status %d body %s", rec.Code, rec.Body.String())
+	}
+	if rec := do(t, "GET", "/ping", ""); rec.Code != http.StatusOK {
+		t.Errorf("/ping: status %d", rec.Code)
+	}
+}
+
+// The shared llmcore fix must land here too.
+func TestMaxTokensHonoured(t *testing.T) {
+	rec := do(t, "POST", "/v1/chat/completions",
+		`{"model":"`+defaultModel+`","messages":[{"role":"user","content":"Reply with OK."}],"max_tokens":1}`)
+	if !strings.Contains(rec.Body.String(), `"finish_reason":"length"`) {
+		t.Errorf("want finish_reason length: %s", rec.Body.String())
+	}
+}

--- a/vllm/metrics.go
+++ b/vllm/metrics.go
@@ -1,0 +1,128 @@
+package vllm
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Prometheus text exposition for /metrics. Captured prod traffic makes this the single
+// most-requested path on the vLLM honeypot (16 hits from 11 distinct IPs, largely Palo Alto
+// Xpanse and similar fingerprinting scanners) and it previously returned a JSON 404 — the
+// clearest signal on the honeypot that nothing was actually serving.
+//
+// Counters are derived from process uptime so consecutive scrapes advance monotonically, the
+// way a real exporter behaves. A static body that never changes is its own tell.
+
+const metricsContentType = "text/plain; version=0.0.4; charset=utf-8"
+
+var startedAt = time.Now()
+
+// counterAt returns a monotonically increasing count for a metric accruing at roughly
+// ratePerSecond, with a small deterministic offset so different metrics do not move in lockstep.
+func counterAt(ratePerSecond, seed float64) float64 {
+	elapsed := time.Since(startedAt).Seconds()
+	return math.Floor(elapsed*ratePerSecond + seed)
+}
+
+type histBucket struct {
+	le    string
+	count float64
+}
+
+func writeHistogram(b *strings.Builder, name, help string, labels string, buckets []histBucket, sum float64) {
+	fmt.Fprintf(b, "# HELP %s %s\n# TYPE %s histogram\n", name, help, name)
+	var total float64
+	for _, bk := range buckets {
+		total = bk.count
+		fmt.Fprintf(b, "%s_bucket{%s,le=\"%s\"} %g\n", name, labels, bk.le, bk.count)
+	}
+	fmt.Fprintf(b, "%s_bucket{%s,le=\"+Inf\"} %g\n", name, labels, total)
+	fmt.Fprintf(b, "%s_count{%s} %g\n", name, labels, total)
+	fmt.Fprintf(b, "%s_sum{%s} %g\n", name, labels, sum)
+}
+
+func handleMetrics(w http.ResponseWriter, r *http.Request) {
+	labels := fmt.Sprintf("model_name=%q", defaultModel)
+	prompt := counterAt(41.7, 18422)
+	gen := counterAt(12.3, 7311)
+	success := counterAt(0.21, 143)
+	running := float64(rand.Intn(3))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "# HELP vllm:cache_config_info Information of the LLMEngine CacheConfig\n"+
+		"# TYPE vllm:cache_config_info gauge\n"+
+		"vllm:cache_config_info{block_size=\"16\",cache_dtype=\"auto\",enable_prefix_caching=\"False\","+
+		"gpu_memory_utilization=\"0.9\",num_gpu_blocks=\"7684\",num_cpu_blocks=\"2048\",swap_space_bytes=\"4294967296\"} 1.0\n")
+
+	gauges := []struct {
+		name, help string
+		value      float64
+	}{
+		{"vllm:num_requests_running", "Number of requests currently running on GPU.", running},
+		{"vllm:num_requests_swapped", "Number of requests swapped to CPU.", 0},
+		{"vllm:num_requests_waiting", "Number of requests waiting to be processed.", 0},
+		{"vllm:gpu_cache_usage_perc", "GPU KV-cache usage. 1 means 100 percent usage.", 0.0142 + running*0.031},
+		{"vllm:cpu_cache_usage_perc", "CPU KV-cache usage. 1 means 100 percent usage.", 0},
+		{"vllm:gpu_prefix_cache_hit_rate", "GPU prefix cache block hit rate.", -1},
+		{"vllm:cpu_prefix_cache_hit_rate", "CPU prefix cache block hit rate.", -1},
+		{"vllm:avg_prompt_throughput_toks_per_s", "Average prefill throughput in tokens/s.", 0},
+		{"vllm:avg_generation_throughput_toks_per_s", "Average generation throughput in tokens/s.", 0},
+	}
+	for _, g := range gauges {
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s gauge\n%s{%s} %g\n",
+			g.name, g.help, g.name, g.name, labels, g.value)
+	}
+
+	counters := []struct {
+		name, help string
+		value      float64
+		extra      string
+	}{
+		{"vllm:num_preemptions", "Cumulative number of preemption from the engine.", 0, ""},
+		{"vllm:prompt_tokens", "Number of prefill tokens processed.", prompt, ""},
+		{"vllm:generation_tokens", "Number of generation tokens processed.", gen, ""},
+		{"vllm:request_success", "Count of successfully processed requests.", success, ",finished_reason=\"stop\""},
+	}
+	for _, c := range counters {
+		fmt.Fprintf(&b, "# HELP %s_total %s\n# TYPE %s_total counter\n%s_total{%s%s} %g\n",
+			c.name, c.help, c.name, c.name, labels, c.extra, c.value)
+	}
+
+	writeHistogram(&b, "vllm:time_to_first_token_seconds", "Histogram of time to first token in seconds.", labels,
+		[]histBucket{
+			{"0.001", 0}, {"0.005", 0}, {"0.01", 2}, {"0.02", 11}, {"0.04", 37},
+			{"0.06", 61}, {"0.08", 79}, {"0.1", 94}, {"0.25", 118}, {"0.5", 129},
+			{"0.75", 133}, {"1.0", math.Floor(success * 0.97)}, {"2.5", success},
+		}, success*0.18)
+	writeHistogram(&b, "vllm:time_per_output_token_seconds", "Histogram of time per output token in seconds.", labels,
+		[]histBucket{
+			{"0.01", 4}, {"0.025", 58}, {"0.05", math.Floor(gen * 0.81)}, {"0.075", math.Floor(gen * 0.94)},
+			{"0.1", math.Floor(gen * 0.98)}, {"0.15", gen},
+		}, gen*0.031)
+	writeHistogram(&b, "vllm:e2e_request_latency_seconds", "Histogram of end to end request latency in seconds.", labels,
+		[]histBucket{
+			{"1.0", math.Floor(success * 0.22)}, {"2.5", math.Floor(success * 0.61)},
+			{"5.0", math.Floor(success * 0.88)}, {"10.0", math.Floor(success * 0.97)},
+			{"15.0", success}, {"20.0", success}, {"30.0", success},
+		}, success*3.4)
+	writeHistogram(&b, "vllm:request_prompt_tokens", "Number of prefill tokens processed.", labels,
+		[]histBucket{
+			{"1", 0}, {"2", 0}, {"5", 3}, {"10", 19}, {"20", 52},
+			{"50", math.Floor(success * 0.72)}, {"100", math.Floor(success * 0.91)},
+			{"200", math.Floor(success * 0.99)}, {"500", success}, {"1000", success},
+		}, prompt)
+	writeHistogram(&b, "vllm:request_generation_tokens", "Number of generation tokens processed.", labels,
+		[]histBucket{
+			{"1", 2}, {"2", 6}, {"5", 24}, {"10", 61},
+			{"20", math.Floor(success * 0.78)}, {"50", math.Floor(success * 0.95)},
+			{"100", success}, {"200", success},
+		}, gen)
+
+	w.Header().Set("Content-Type", metricsContentType)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(b.String()))
+}

--- a/vllm/vllm.go
+++ b/vllm/vllm.go
@@ -18,6 +18,9 @@ const (
 	defaultPort  = "8000"
 	defaultModel = "meta-llama/Meta-Llama-3-8B-Instruct"
 	serverHeader = "uvicorn"
+	// vllmVersion is reported by /version and stamped into the OpenAPI schema. Unlike Ollama,
+	// uvicorn genuinely does send a Server header, so serverHeader above stays.
+	vllmVersion = "0.6.3"
 )
 
 var modelsCreated = time.Now().Unix()
@@ -59,29 +62,73 @@ func identityHeaders(next http.Handler) http.Handler {
 	})
 }
 
+// profile is vLLM's OpenAI surface: bare application/json (FastAPI adds no charset), no
+// system_fingerprint (vLLM omits the field entirely, unlike Ollama), long opaque completion ids,
+// and no model catalog — vLLM serves whatever single model it was launched with, so it does not
+// have Ollama's notion of a model that could be absent.
+var profile = llmcore.Profile{
+	DefaultModel: defaultModel,
+	ContentType:  llmcore.CTJSON,
+}
+
 func newRouter() http.Handler {
 	r := mux.NewRouter()
-	r.HandleFunc("/v1/models", handleModels).Methods("GET")
+	get := []string{http.MethodGet, http.MethodHead}
+
+	r.HandleFunc("/v1/models", handleModels).Methods(get...)
 	r.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.ChatCompletion(w, req, defaultModel)
+		llmcore.ChatCompletion(w, req, profile)
 	}).Methods("POST")
 	r.HandleFunc("/v1/completions", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.Completion(w, req, defaultModel)
+		llmcore.Completion(w, req, profile)
 	}).Methods("POST")
-	r.HandleFunc("/health", handleHealth).Methods("GET")
-	r.HandleFunc("/version", handleVersion).Methods("GET")
+	r.HandleFunc("/v1/embeddings", handleEmbeddings).Methods("POST")
+	r.HandleFunc("/health", handleHealth).Methods(get...)
+	r.HandleFunc("/ping", handleHealth).Methods(get...)
+	r.HandleFunc("/version", handleVersion).Methods(get...)
+	// The endpoint Xpanse and friends actually scrape.
+	r.HandleFunc("/metrics", handleMetrics).Methods(get...)
+	r.HandleFunc("/tokenize", handleTokenize).Methods("POST")
+	r.HandleFunc("/detokenize", handleDetokenize).Methods("POST")
+	// FastAPI mounts interactive docs by default; their absence on a box that is otherwise
+	// obviously FastAPI is itself a discrepancy.
+	r.HandleFunc("/openapi.json", handleOpenAPI).Methods(get...)
+	r.HandleFunc("/docs", handleDocs).Methods(get...)
 	r.PathPrefix("/").HandlerFunc(handleCatchAll)
 	return r
 }
 
+// Response payloads are structs rather than maps so the JSON key order matches the real
+// server's; encoding/json sorts map keys alphabetically, which no real implementation does.
+
+type modelPermission struct {
+	ID     string `json:"id"`
+	Object string `json:"object"`
+}
+
+type modelEntry struct {
+	ID          string            `json:"id"`
+	Object      string            `json:"object"`
+	Created     int64             `json:"created"`
+	OwnedBy     string            `json:"owned_by"`
+	Root        string            `json:"root"`
+	Parent      *string           `json:"parent"`
+	MaxModelLen int               `json:"max_model_len"`
+	Permission  []modelPermission `json:"permission"`
+}
+
+type modelsResponse struct {
+	Object string       `json:"object"`
+	Data   []modelEntry `json:"data"`
+}
+
 func handleModels(w http.ResponseWriter, r *http.Request) {
-	created := modelsCreated
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
-		"object": "list",
-		"data": []map[string]any{{
-			"id": defaultModel, "object": "model", "created": created, "owned_by": "vllm",
-			"root": defaultModel, "parent": nil,
-			"permission": []map[string]any{{"id": "modelperm-vllm", "object": "model_permission"}},
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, modelsResponse{
+		Object: "list",
+		Data: []modelEntry{{
+			ID: defaultModel, Object: "model", Created: modelsCreated, OwnedBy: "vllm",
+			Root: defaultModel, MaxModelLen: 8192,
+			Permission: []modelPermission{{ID: "modelperm-vllm", Object: "model_permission"}},
 		}},
 	})
 }
@@ -90,10 +137,60 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func handleVersion(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{"version": "0.5.4"})
+type versionResponse struct {
+	Version string `json:"version"`
 }
 
+func handleVersion(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, versionResponse{Version: vllmVersion})
+}
+
+func handleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	// A generative model served by vLLM has no embedding task, and this is the error it gives.
+	llmcore.WriteOpenAIError(w, profile, http.StatusBadRequest,
+		"The model does not support Embeddings API", "BadRequestError")
+}
+
+type tokenizeResponse struct {
+	Count       int    `json:"count"`
+	MaxModelLen int    `json:"max_model_len"`
+	Tokens      []int  `json:"tokens"`
+	TokenStrs   *[]int `json:"token_strs"`
+}
+
+func handleTokenize(w http.ResponseWriter, r *http.Request) {
+	text := llmcore.PromptOf(r)
+	tokens := llmcore.PseudoTokens(text)
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, tokenizeResponse{
+		Count: len(tokens), MaxModelLen: 8192, Tokens: tokens,
+	})
+}
+
+type detokenizeResponse struct {
+	Prompt string `json:"prompt"`
+}
+
+func handleDetokenize(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, detokenizeResponse{Prompt: ""})
+}
+
+func handleOpenAPI(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, openAPISchema())
+}
+
+func handleDocs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, swaggerHTML)
+}
+
+// handleCatchAll reproduces FastAPI's default 404 body. The previous OpenAI-style error envelope
+// was wrong for every unrouted path: FastAPI answers {"detail":"Not Found"}, and vLLM does not
+// customise it.
 func handleCatchAll(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteError(w, http.StatusNotFound, "Not Found", "invalid_request_error", "")
+	llmcore.WriteJSONCT(w, http.StatusNotFound, llmcore.CTJSON, detailResponse{Detail: "Not Found"})
+}
+
+type detailResponse struct {
+	Detail string `json:"detail"`
 }


### PR DESCRIPTION
## Why

Prod capture since Jul 23 holds **237 LLM-honeypot requests**, 85% of them Ollama. Every one of those responses was distinguishable from a real Ollama in a single request — before the attacker sent anything worth capturing.

All target behaviour here was captured from a **real Ollama 0.30.11 running locally**, not from documentation or recall.

## Traffic that drove the priorities

| honeypot | rows | notable |
|---|---|---|
| ollama | 201 | every model probed (`mistral:latest` ×31, `llama3.2:latest` ×30) is one we advertise — scanners read `/api/tags`, then probe what they find |
| vllm | 22 | `GET /metrics` is 16 of them, from 11 distinct IPs |
| localai / llamacpp / comfyui | 14 | health checks and generic scanning |

Probes are liveness checks (`say pong`, `Reply with OK.`, `Count to five.`) from `python-httpx`, `open-router-cli/2.34.0`, `Ollama-Scanner/1.0`, `multi-agent-console/1.0`, plus Censys, zgrab and Palo Alto Xpanse.

## Tier 1 — passive fingerprints, wrong on 100% of responses

| | Real Ollama | Before |
|---|---|---|
| `Server` header | **absent** (Gin sets none) | `Server: Ollama` — an invented header, so a *positive* honeypot signature |
| `/api/*` content-type | `application/json; charset=utf-8` | `application/json` |
| `/v1/*` content-type | `application/json` | `application/json` ✓ |
| unrouted path | `404 page not found`, `text/plain` | `{"error":"not found"}`, JSON |
| wrong method | `405 method not allowed` + `Allow:` | fell through to 404 |
| `HEAD /` | 200 | 404 (mux doesn't imply HEAD from GET) |
| CORS | `Access-Control-Allow-Origin`, 204 preflight | none |
| JSON encoding | struct order, no trailing newline | map order (alphabetical), `Encoder.Encode` newline |

The last row is subtle and pervasive: `encoding/json` sorts map keys, so every map-built payload had a key order no real implementation emits, and `Encoder.Encode` made every `Content-Length` one byte high.

## Tier 2 — live traffic that hit nothing

- **vLLM `/metrics`** — the busiest vLLM path, previously a JSON 404. Now Prometheus text exposition with counters derived from uptime, so consecutive scrapes advance.
- **`POST /api/pull`** — 3 IPs pulling `llama3.2:1b`. Now streams plausible NDJSON progress and **registers the model**, so the attacker finds it in `/api/tags` and goes on to use it. Deliberate divergence: nothing is downloaded.
- **`POST /v1/responses`** — probed by `open-router-cli` using models we advertise; real modern Ollama implements it.

## Tier 3 — generator fidelity

`ollamaFinal()` hardcoded `total_duration: 1234567890`, `load_duration: 123456`, `eval_duration: 987654`, `prompt_eval_count: 12`, `eval_count: 24` — **byte-identical on every request**. Durations are now derived from token counts with jitter and model residency. Also added: `system_fingerprint: "fp_ollama"`, per-chunk `created_at`, the `context` token array, `done_reason` and the `*_duration` fields on `/api/chat`, and `max_tokens`/`num_predict` handling so hitting the cap reports `finish_reason: "length"`.

Unknown models, malformed JSON and `/api/show` without a name now return the real 404/400 responses.

## Decisions worth flagging

**Error strictness → faithful.** Permissiveness retains no attacker a real box would have retained: a scanner probing a hardcoded model name gets 404 from every genuine Ollama too, so its tooling already handles that by reading `/api/tags` and retrying. It bought nothing and cost a tell.

**Catalog 2 → 6 models.** The mitigation for "attacker probes a model we lack" is a bigger shelf, not lying. `llama3.2:latest` and `mistral:latest` keep their exact names, sizes and digests — captured traffic shows the validation loop through those names already works, and renaming would break it.

**Version → 0.30.11.** Implementing `/v1/responses`, `capabilities[]` and `context_length` while claiming 0.3.12 would be an impossible combination.

## Testing

- `ollama/fidelity_test.go`, `vllm/fidelity_test.go` — each behaviour pinned with the reference transcript quoted inline.
- `ollama/reference_diff_test.go` — diffs the honeypot against a **live** Ollama when `OLLAMA_REFERENCE_URL` is set; skipped in CI. **17/17 subtests pass against 0.30.11** on status, content-type, `Server`, `Allow`, and byte-exact bodies on every error path.
- `TestServerHeaderSurvivesCmdrespOverride` is inverted into `TestCORSSurvivesCmdrespOverride` — it now asserts the `Server` header is *never* set, while keeping the middleware-ordering guarantee it was written for.
- Full suite green: 30 packages, 0 failures.

## Not in scope

The remaining gap between `llmcore/filter.go`'s declared signal surface and the routers — Ray's job-submit chain, llama.cpp `/slots` `/tokenize` `/infill`, ComfyUI `/history` `/interrupt`, LocalAI `/models/apply`. Ray has zero captured rows, so that is optimising for traffic that has not appeared. Filed as follow-up.

PRD: `prd/033-llm-honeypot-response-fidelity.md` in the server repo.
Issues: `threat_gg-5u3`, `threat_gg-z6s`, `threat_gg-8if`, `threat_gg-yee`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
