### PR TITLE
fix(ollama): use sha256 for synthesised model digests

### DIFF
--- a/ollama/catalog.go
+++ b/ollama/catalog.go
@@ -1,7 +1,8 @@
 package ollama
 
 import (
-	"fmt"
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"sync"
 	"time"
@@ -250,17 +251,13 @@ func synthesize(name string) CatalogModel {
 }
 
 // pseudoDigest derives a stable 64-hex-character digest from a model name, so the same pulled
-// model always reports the same digest across /api/tags and /api/show.
+// model always reports the same digest across /api/tags, /api/show and the pull progress stream.
+//
+// This must be a real hash. An earlier version concatenated four FNV-1a hashes of the same name
+// with a trailing counter, which produced visibly correlated 8-byte blocks —
+// 9b7b80336b17…9b7b81336b17…9b7b82336b17 — where a genuine sha256 is uniformly random. That
+// pattern was legible in the /api/pull stream and was a fingerprint in its own right.
 func pseudoDigest(name string) string {
-	// FNV-1a, expanded to 32 bytes by re-hashing with a counter.
-	var out strings.Builder
-	for i := 0; i < 4; i++ {
-		h := uint64(1469598103934665603)
-		for _, b := range []byte(fmt.Sprintf("%s/%d", name, i)) {
-			h ^= uint64(b)
-			h *= 1099511628211
-		}
-		fmt.Fprintf(&out, "%016x", h)
-	}
-	return out.String()
+	sum := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(sum[:])
 }

--- a/ollama/digest_test.go
+++ b/ollama/digest_test.go
@@ -1,0 +1,33 @@
+package ollama
+
+import "testing"
+
+// Regression for the correlated-digest defect: an earlier pseudoDigest concatenated four FNV-1a
+// hashes of the same name plus a counter, producing visibly repeating 8-byte blocks where a real
+// sha256 is uniformly random.
+func TestPseudoDigestHasNoRepeatingBlocks(t *testing.T) {
+	for _, name := range []string{"llama3.2:1b", "mistral:7b", "qwen2.5:0.5b"} {
+		d := pseudoDigest(name)
+		if len(d) != 64 {
+			t.Fatalf("%s: digest length %d, want 64", name, len(d))
+		}
+		seen := map[string]bool{}
+		for i := 0; i+8 <= len(d); i += 8 {
+			blk := d[i : i+8]
+			if seen[blk] {
+				t.Errorf("%s: repeated 8-char block %q in %s", name, blk, d)
+			}
+			seen[blk] = true
+		}
+		// The old bug made blocks differ only in one nibble; require real divergence.
+		if d[0:6] == d[16:22] || d[0:6] == d[32:38] {
+			t.Errorf("%s: correlated blocks in %s", name, d)
+		}
+	}
+	if pseudoDigest("a") == pseudoDigest("b") {
+		t.Error("digest is not name-dependent")
+	}
+	if pseudoDigest("a") != pseudoDigest("a") {
+		t.Error("digest is not stable")
+	}
+}


### PR DESCRIPTION
Follow-up to #30, caught while verifying the deploy on a live honeypot.

The `/api/pull` progress stream showed this:

```
{"status":"pulling 9b7b80336b17","digest":"sha256:9b7b80336b17bf009b7b81336b17c0b39b7b82336b17c2669b7b83336b17c419"}
```

`9b7b80336b17` … `9b7b81336b17` … `9b7b82336b17` … `9b7b83336b17`. `pseudoDigest` built its 64 hex characters from four FNV-1a hashes of the model name plus a counter; FNV-1a diffuses poorly, so inputs differing in one byte gave 8-byte blocks differing in one nibble. A real sha256 is uniformly random, so that repetition was a fingerprint in its own right — on the endpoint that was just added to look convincing.

sha256 of the name gives exactly 32 bytes, is stable per name, and needs no concatenation. Regression test asserts no repeated or correlated 8-character blocks, plus stability and name-dependence.

Full suite green (30 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)