### PR TITLE
LLM honeypot fidelity: llama.cpp /tokenize /detokenize /slots, ComfyUI /history, LocalAI /healthz + /v1/embeddings (5fb, 5g1, 3kd)

### DIFF
--- a/comfyui/comfyui.go
+++ b/comfyui/comfyui.go
@@ -44,8 +44,25 @@ func newRouter() http.Handler {
 	r.HandleFunc("/queue", handleQueue).Methods("GET")
 	r.HandleFunc("/prompt", handlePrompt).Methods("POST")
 	r.HandleFunc("/prompt", handlePromptGet).Methods("GET")
+	// threat_gg-3kd: verified 404 on the live fleet. Every real client polls /history after
+	// submitting a workflow via /prompt. Response shape verified against the current source
+	// (github.com/comfyanonymous/ComfyUI execution.py, PromptQueue.get_history): this honeypot
+	// never actually executes a submitted workflow, so both the collection and any specific
+	// prompt_id are always the "nothing recorded yet" case, which real ComfyUI also renders as
+	// an empty JSON object — not a guess, the literal return value of that code path.
+	r.HandleFunc("/history", handleHistory).Methods("GET")
+	r.HandleFunc("/history/{prompt_id}", handleHistory).Methods("GET")
 	r.PathPrefix("/").HandlerFunc(handleCatchAll)
 	return r
+}
+
+// handleHistory serves both GET /history and GET /history/{prompt_id}. Real ComfyUI's
+// PromptQueue.get_history returns {} for the no-argument case on a fresh instance (self.history
+// starts empty) and {} for any prompt_id not present in self.history — which, since nothing this
+// honeypot "runs" via /prompt ever actually completes, is every prompt_id it will ever be asked
+// about. Both routes are therefore the same response.
+func handleHistory(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSON(w, http.StatusOK, map[string]any{})
 }
 
 func handleSystemStats(w http.ResponseWriter, r *http.Request) {

--- a/comfyui/fidelity_test.go
+++ b/comfyui/fidelity_test.go
@@ -1,6 +1,7 @@
 package comfyui
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,15 +13,21 @@ import (
 // this honeypot never actually executes a submitted /prompt workflow, so both cases are always
 // true here.
 
-func do(t *testing.T, method, path string) *httptest.ResponseRecorder {
+func do(t *testing.T, method, path, body string) *httptest.ResponseRecorder {
 	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
 	rec := httptest.NewRecorder()
-	newRouter().ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	newRouter().ServeHTTP(rec, r)
 	return rec
 }
 
 func TestHistoryIsEmptyObject(t *testing.T) {
-	rec := do(t, "GET", "/history")
+	rec := do(t, "GET", "/history", "")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d, want 200", rec.Code)
 	}
@@ -30,11 +37,38 @@ func TestHistoryIsEmptyObject(t *testing.T) {
 }
 
 func TestHistoryByPromptIDIsEmptyObject(t *testing.T) {
-	rec := do(t, "GET", "/history/00000000-0000-4000-8000-000000000000")
+	rec := do(t, "GET", "/history/00000000-0000-4000-8000-000000000000", "")
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d, want 200", rec.Code)
 	}
 	if got := strings.TrimSpace(rec.Body.String()); got != "{}" {
 		t.Errorf("body %q, want %q", got, "{}")
+	}
+}
+
+// PR #33 review: the two tests above only prove /history is {} on a fresh router — they would
+// still pass even if a regression started recording submitted prompts into some in-memory
+// history. The actual contract is that /history stays {} *after* a workflow has been submitted
+// via /prompt too, since this honeypot never executes what it accepts.
+func TestHistoryStaysEmptyAfterPromptSubmission(t *testing.T) {
+	promptRec := do(t, "POST", "/prompt", `{"prompt":{"1":{"class_type":"KSampler"}}}`)
+	if promptRec.Code != http.StatusOK {
+		t.Fatalf("/prompt: status %d", promptRec.Code)
+	}
+	var promptResp struct {
+		PromptID string `json:"prompt_id"`
+	}
+	if err := json.Unmarshal(promptRec.Body.Bytes(), &promptResp); err != nil {
+		t.Fatalf("unmarshal /prompt response: %v; body=%s", err, promptRec.Body.String())
+	}
+	if promptResp.PromptID == "" {
+		t.Fatal("/prompt did not return a prompt_id")
+	}
+
+	if got := strings.TrimSpace(do(t, "GET", "/history", "").Body.String()); got != "{}" {
+		t.Errorf("/history after submission: body %q, want %q", got, "{}")
+	}
+	if got := strings.TrimSpace(do(t, "GET", "/history/"+promptResp.PromptID, "").Body.String()); got != "{}" {
+		t.Errorf("/history/%s after submission: body %q, want %q", promptResp.PromptID, got, "{}")
 	}
 }

--- a/comfyui/fidelity_test.go
+++ b/comfyui/fidelity_test.go
@@ -1,0 +1,40 @@
+package comfyui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for threat_gg-3kd. Real ComfyUI's PromptQueue.get_history (execution.py)
+// returns {} both when nothing has ever completed and when a specific prompt_id is unknown —
+// this honeypot never actually executes a submitted /prompt workflow, so both cases are always
+// true here.
+
+func do(t *testing.T, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	newRouter().ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec
+}
+
+func TestHistoryIsEmptyObject(t *testing.T) {
+	rec := do(t, "GET", "/history")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "{}" {
+		t.Errorf("body %q, want %q", got, "{}")
+	}
+}
+
+func TestHistoryByPromptIDIsEmptyObject(t *testing.T) {
+	rec := do(t, "GET", "/history/00000000-0000-4000-8000-000000000000")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "{}" {
+		t.Errorf("body %q, want %q", got, "{}")
+	}
+}

--- a/llamacpp/endpoints.go
+++ b/llamacpp/endpoints.go
@@ -2,6 +2,7 @@ package llamacpp
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/joshrendek/threat.gg-agent/llmcore"
 )
@@ -44,15 +45,14 @@ func handleTokenize(w http.ResponseWriter, r *http.Request) {
 	var req tokenizeRequest
 	readJSONBody(r, &req)
 
-	tokens := llmcore.PseudoTokens(req.Content)
+	ids, chunks := deterministicTokens(req.Content, clientIP(r))
 	if !req.WithPieces {
-		llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, tokenizeResponse{Tokens: tokens})
+		llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, tokenizeResponse{Tokens: ids})
 		return
 	}
 
-	chunks := splitIntoChunks(req.Content, len(tokens))
-	pieces := make([]tokenPiece, len(tokens))
-	for i, id := range tokens {
+	pieces := make([]tokenPiece, len(ids))
+	for i, id := range ids {
 		pieces[i] = tokenPiece{ID: id, Piece: chunks[i]}
 	}
 	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, tokenizeResponse{Tokens: pieces})
@@ -97,15 +97,24 @@ type detokenizeResponse struct {
 	Content string `json:"content"`
 }
 
-// handleDetokenize always answers with the empty string. Real llama.cpp round-trips the token
-// ids through its own vocabulary; the ids our /tokenize hands out are fabricated (see
-// llmcore.PseudoTokens) and correspond to no real vocabulary, so there is nothing correct to
-// reverse them into. Matches vLLM's handleDetokenize stub for the same reason: an honest "we
-// don't know" reads better than a fabricated string that would not survive a careful check.
+// handleDetokenize reconstructs text from ids previously issued to this same source IP by
+// /tokenize (see tokencache.go): /tokenize's ids are a deterministic hash of their own piece
+// text, remembered in a bounded per-IP cache at issue time, so a tokenize-then-detokenize probe
+// — the realistic use of this endpoint — gets its original text back, byte for byte. An id this
+// cache never saw for this IP (never issued, evicted, or from a different source) contributes
+// nothing rather than fabricated text, which degrades gracefully instead of lying.
 func handleDetokenize(w http.ResponseWriter, r *http.Request) {
 	var req detokenizeRequest
 	readJSONBody(r, &req)
-	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, detokenizeResponse{Content: ""})
+
+	ip := clientIP(r)
+	var content strings.Builder
+	for _, id := range req.Tokens {
+		if piece, ok := tokenMemory.lookup(ip, id); ok {
+			content.WriteString(piece)
+		}
+	}
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, detokenizeResponse{Content: content.String()})
 }
 
 // -- GET /slots

--- a/llamacpp/endpoints.go
+++ b/llamacpp/endpoints.go
@@ -1,0 +1,131 @@
+package llamacpp
+
+import (
+	"net/http"
+
+	"github.com/joshrendek/threat.gg-agent/llmcore"
+)
+
+// threat_gg-5g1: POST /tokenize, POST /detokenize and GET /slots were verified 404 on the live
+// fleet. All three are standard llama-server endpoints; shapes below are confirmed against the
+// current server source, not just the README, since the README's /detokenize section documents
+// only the request fields and omits the response shape entirely:
+//
+//	github.com/ggml-org/llama.cpp tools/server/server-context.cpp
+//	  post_tokenize   (~line 4870): {"tokens": [...]}, or [{"id","piece"}, ...] with with_pieces
+//	  post_detokenize (~line 4911): {"content": "..."}
+//	  get_slots       (~line 4445): array of server_slot::to_json() (~line 632); an idle slot with
+//	                  no completions ever run on it (our case, always) reduces to
+//	                  {"id","n_ctx","speculative","is_processing"} with no "params"/"prompt"/
+//	                  "next_token" (those only appear once a task has run on the slot).
+
+// -- POST /tokenize
+
+type tokenizeRequest struct {
+	Content    string `json:"content"`
+	WithPieces bool   `json:"with_pieces"`
+}
+
+// tokenPiece is the with_pieces:true shape. Real llama.cpp emits piece as a []byte array instead
+// of a string when the token's bytes are not valid UTF-8; ours are always valid UTF-8 substrings
+// of the input, so the string form is all this honeypot ever needs.
+type tokenPiece struct {
+	ID    int    `json:"id"`
+	Piece string `json:"piece"`
+}
+
+type tokenizeResponse struct {
+	// Tokens holds either []int (with_pieces false) or []tokenPiece (with_pieces true) — the
+	// two shapes the real endpoint switches between on the same field.
+	Tokens any `json:"tokens"`
+}
+
+func handleTokenize(w http.ResponseWriter, r *http.Request) {
+	var req tokenizeRequest
+	readJSONBody(r, &req)
+
+	tokens := llmcore.PseudoTokens(req.Content)
+	if !req.WithPieces {
+		llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, tokenizeResponse{Tokens: tokens})
+		return
+	}
+
+	chunks := splitIntoChunks(req.Content, len(tokens))
+	pieces := make([]tokenPiece, len(tokens))
+	for i, id := range tokens {
+		pieces[i] = tokenPiece{ID: id, Piece: chunks[i]}
+	}
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, tokenizeResponse{Tokens: pieces})
+}
+
+// splitIntoChunks divides content into n contiguous, non-overlapping runs of runes (so a
+// with_pieces response at least looks like a segmentation of the real input instead of unrelated
+// placeholder text). n is always >= 1 (see llmcore.PseudoTokens); an empty content yields n empty
+// strings.
+func splitIntoChunks(content string, n int) []string {
+	if n < 1 {
+		n = 1
+	}
+	runes := []rune(content)
+	out := make([]string, n)
+	chunkSize := len(runes) / n
+	if chunkSize < 1 {
+		chunkSize = 1
+	}
+	pos := 0
+	for i := 0; i < n; i++ {
+		if pos >= len(runes) {
+			continue
+		}
+		end := pos + chunkSize
+		if i == n-1 || end > len(runes) {
+			end = len(runes)
+		}
+		out[i] = string(runes[pos:end])
+		pos = end
+	}
+	return out
+}
+
+// -- POST /detokenize
+
+type detokenizeRequest struct {
+	Tokens []int `json:"tokens"`
+}
+
+type detokenizeResponse struct {
+	Content string `json:"content"`
+}
+
+// handleDetokenize always answers with the empty string. Real llama.cpp round-trips the token
+// ids through its own vocabulary; the ids our /tokenize hands out are fabricated (see
+// llmcore.PseudoTokens) and correspond to no real vocabulary, so there is nothing correct to
+// reverse them into. Matches vLLM's handleDetokenize stub for the same reason: an honest "we
+// don't know" reads better than a fabricated string that would not survive a careful check.
+func handleDetokenize(w http.ResponseWriter, r *http.Request) {
+	var req detokenizeRequest
+	readJSONBody(r, &req)
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, detokenizeResponse{Content: ""})
+}
+
+// -- GET /slots
+
+// slotInfo is server_slot::to_json(only_metrics=true) for a slot that has never run a task: real
+// llama.cpp only adds "id_task"/"n_prompt_tokens"/"params"/"next_token"/etc. once ptask (the
+// slot's current or most recent task) is non-null. A slot in this honeypot never actually runs a
+// completion internally, so it stays in that minimal shape indefinitely — which is also exactly
+// the shape a freshly started real server reports before its first request.
+type slotInfo struct {
+	ID           int  `json:"id"`
+	NCtx         int  `json:"n_ctx"`
+	Speculative  bool `json:"speculative"`
+	IsProcessing bool `json:"is_processing"`
+}
+
+// handleSlots reports a single idle slot, matching the total_slots:1 (the default --parallel
+// value) already advertised by /props.
+func handleSlots(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, []slotInfo{
+		{ID: 0, NCtx: slotNCtx, Speculative: false, IsProcessing: false},
+	})
+}

--- a/llamacpp/fidelity_test.go
+++ b/llamacpp/fidelity_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -162,28 +161,79 @@ func TestTokenize(t *testing.T) {
 	if rebuilt.String() != "hello world" {
 		t.Errorf("pieces do not reconstruct the input: got %q, want %q", rebuilt.String(), "hello world")
 	}
+
+	// Tokenization is deterministic (tokencache.go): the same content from the same source must
+	// produce the same ids whether or not with_pieces was set, since with_pieces the real server
+	// only adds a "piece" alongside each id, it does not change which ids are issued.
+	if len(resp.Tokens) != len(piecesResp.Tokens) {
+		t.Fatalf("plain vs with_pieces token count differs: %d vs %d", len(resp.Tokens), len(piecesResp.Tokens))
+	}
+	for i, id := range resp.Tokens {
+		if piecesResp.Tokens[i].ID != id {
+			t.Errorf("token %d: plain id %d, with_pieces id %d — should match", i, id, piecesResp.Tokens[i].ID)
+		}
+	}
 }
 
-// POST /detokenize: {"content": "..."} — verified against post_detokenize. We hold no real
-// vocabulary to reverse fabricated /tokenize ids through, so the honest answer is empty.
-func TestDetokenize(t *testing.T) {
-	rec := do(t, "POST", "/detokenize", `{"tokens":[1000,2000,3000]}`)
+// POST /detokenize must round-trip a real /tokenize call's own ids back into the original text
+// (PR #33 review, ERROR 2): tokenization is deterministic and each issued id is remembered
+// against its piece (tokencache.go), so tokenize-then-detokenize — the realistic probe pattern —
+// reconstructs the input exactly rather than answering "".
+func TestDetokenizeRoundTripsTokenizeOutput(t *testing.T) {
+	const original = "the quick brown fox jumps over the lazy dog"
+
+	tokenizeRec := do(t, "POST", "/tokenize", `{"content":"`+original+`"}`)
+	var tokenizeResp struct {
+		Tokens []int `json:"tokens"`
+	}
+	if err := json.Unmarshal(tokenizeRec.Body.Bytes(), &tokenizeResp); err != nil {
+		t.Fatalf("unmarshal /tokenize: %v; body=%s", err, tokenizeRec.Body.String())
+	}
+	if len(tokenizeResp.Tokens) == 0 {
+		t.Fatal("no tokens returned")
+	}
+
+	ids, err := json.Marshal(tokenizeResp.Tokens)
+	if err != nil {
+		t.Fatalf("marshal token ids: %v", err)
+	}
+	detokenizeRec := do(t, "POST", "/detokenize", `{"tokens":`+string(ids)+`}`)
+	if detokenizeRec.Code != http.StatusOK {
+		t.Fatalf("status %d", detokenizeRec.Code)
+	}
+	var detokenizeResp struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(detokenizeRec.Body.Bytes(), &detokenizeResp); err != nil {
+		t.Fatalf("unmarshal /detokenize: %v; body=%s", err, detokenizeRec.Body.String())
+	}
+	if detokenizeResp.Content != original {
+		t.Errorf("round trip failed: got %q, want %q", detokenizeResp.Content, original)
+	}
+}
+
+// An id this honeypot never issued (to anyone) has no piece to recover — the honest answer is an
+// empty contribution, not fabricated text.
+func TestDetokenizeUnknownIDsContributeNothing(t *testing.T) {
+	rec := do(t, "POST", "/detokenize", `{"tokens":[999999999]}`)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d", rec.Code)
 	}
 	var resp struct {
-		Content *string `json:"content"`
+		Content string `json:"content"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
 	}
-	if resp.Content == nil {
-		t.Fatal(`"content" key missing from /detokenize response`)
+	if resp.Content != "" {
+		t.Errorf("content = %q, want empty for an id never issued", resp.Content)
 	}
 }
 
 // GET /slots: an array of slot objects, matching total_slots:1 from /props — verified against
-// get_slots / server_slot::to_json in server-context.cpp.
+// get_slots / server_slot::to_json in server-context.cpp. id and speculative are asserted
+// explicitly even though both happen to equal Go's zero value, so a regression that stopped
+// setting them would still be caught.
 func TestSlots(t *testing.T) {
 	rec := do(t, "GET", "/slots", "")
 	if rec.Code != http.StatusOK {
@@ -201,8 +251,14 @@ func TestSlots(t *testing.T) {
 	if len(slots) != 1 {
 		t.Fatalf("got %d slots, want 1 (matches /props total_slots)", len(slots))
 	}
+	if slots[0].ID != 0 {
+		t.Errorf("slot id = %d, want 0", slots[0].ID)
+	}
 	if slots[0].NCtx != slotNCtx {
 		t.Errorf("slot n_ctx = %d, want %d", slots[0].NCtx, slotNCtx)
+	}
+	if slots[0].Speculative {
+		t.Error("this honeypot never advertises speculative decoding")
 	}
 	if slots[0].IsProcessing {
 		t.Error("a fresh slot must not be reported as processing")
@@ -217,12 +273,13 @@ func TestNewEndpointsAreCaptured(t *testing.T) {
 	orig := saveLlamacppRequest
 	t.Cleanup(func() { saveLlamacppRequest = orig })
 
-	var mu sync.Mutex
-	captured := map[string]bool{}
+	// Capture is async (a fire-and-forget goroutine per request — see llmcore.captureAndSave), so
+	// synchronize on a channel rather than polling with sleeps: each save sends its path, and the
+	// test blocks on exactly as many receives as requests were made, with a single bounded timeout
+	// as a backstop against a genuine regression hanging the suite.
+	captured := make(chan string, 3)
 	saveLlamacppRequest = func(req *proto.LlmRequest) error {
-		mu.Lock()
-		captured[req.Path] = true
-		mu.Unlock()
+		captured <- req.Path
 		return nil
 	}
 
@@ -244,22 +301,18 @@ func TestNewEndpointsAreCaptured(t *testing.T) {
 		}
 	}
 
-	// Capture is async (fire-and-forget goroutine); give it a moment to land.
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		mu.Lock()
-		n := len(captured)
-		mu.Unlock()
-		if n == 3 || time.Now().After(deadline) {
-			break
+	want := map[string]bool{"/tokenize": true, "/detokenize": true, "/slots": true}
+	got := map[string]bool{}
+	for i := 0; i < len(want); i++ {
+		select {
+		case path := <-captured:
+			got[path] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for capture; got %v so far, want %v", got, want)
 		}
-		time.Sleep(5 * time.Millisecond)
 	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	for _, path := range []string{"/tokenize", "/detokenize", "/slots"} {
-		if !captured[path] {
+	for path := range want {
+		if !got[path] {
 			t.Errorf("%s was not captured", path)
 		}
 	}

--- a/llamacpp/fidelity_test.go
+++ b/llamacpp/fidelity_test.go
@@ -1,0 +1,266 @@
+package llamacpp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// Regression tests for threat_gg-5g1. llama.cpp's server is cpp-httplib end to end (native and
+// OpenAI-compat routes alike), so every JSON response — including /v1/chat/completions — carries
+// "; charset=utf-8", unlike Ollama and vLLM where only part of the surface does.
+
+func do(t *testing.T, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	rec := httptest.NewRecorder()
+	newRouter().ServeHTTP(rec, r)
+	return rec
+}
+
+// Every JSON-emitting route on this honeypot must carry the charset — verified against
+// tools/server/server-http.cpp (error handler) and the wire behaviour cpp-httplib exhibits
+// end-to-end, including its OpenAI-compat layer (unlike Ollama's, which does not).
+func TestContentTypeCharsetEverywhere(t *testing.T) {
+	for _, tc := range []struct{ method, path, body string }{
+		{"GET", "/props", ""},
+		{"GET", "/health", ""},
+		{"GET", "/v1/models", ""},
+		{"GET", "/slots", ""},
+		{"POST", "/completion", `{"prompt":"hello"}`},
+		{"POST", "/tokenize", `{"content":"hello"}`},
+		{"POST", "/detokenize", `{"tokens":[1,2,3]}`},
+		{"POST", "/v1/chat/completions", `{"messages":[{"role":"user","content":"hi"}]}`},
+		{"GET", "/definitely-not-a-route", ""},
+	} {
+		rec := do(t, tc.method, tc.path, tc.body)
+		if got := rec.Header().Get("Content-Type"); got != "application/json; charset=utf-8" {
+			t.Errorf("%s %s: content-type %q, want application/json; charset=utf-8", tc.method, tc.path, got)
+		}
+	}
+}
+
+// Real cpp-httplib's error_handler always answers a 404 with this exact envelope, regardless of
+// which route's error path would otherwise fire — verified against
+// tools/server/server-http.cpp's srv->set_error_handler.
+func TestNotFoundIsCppHttplibShape(t *testing.T) {
+	rec := do(t, "GET", "/definitely-not-a-route", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status %d, want 404", rec.Code)
+	}
+	want := `{"error":{"message":"File Not Found","type":"not_found_error","code":404}}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body %q, want %q", got, want)
+	}
+}
+
+// /props' chat_template must be Jinja2 (the model's real template), not the Go text/template
+// syntax ("{{ .System }}") an Ollama Modelfile would use on a llama.cpp endpoint.
+func TestPropsChatTemplateIsJinja2(t *testing.T) {
+	rec := do(t, "GET", "/props", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var resp struct {
+		ChatTemplate string `json:"chat_template"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if strings.Contains(resp.ChatTemplate, "{{ .System }}") || strings.Contains(resp.ChatTemplate, "{{ .Prompt }}") {
+		t.Errorf("chat_template still looks like a Go text/template: %q", resp.ChatTemplate)
+	}
+	if !strings.Contains(resp.ChatTemplate, "{%") || !strings.Contains(resp.ChatTemplate, "{{") {
+		t.Errorf("chat_template does not look like Jinja2: %q", resp.ChatTemplate)
+	}
+	if !strings.Contains(resp.ChatTemplate, "[INST]") {
+		t.Errorf("chat_template does not match the advertised Llama-2-chat model: %q", resp.ChatTemplate)
+	}
+}
+
+// /props' key set is verified against the README's documented shape (see props.go's source
+// comment): default_generation_settings, total_slots, model_path, chat_template,
+// chat_template_caps, modalities, media_marker, build_info, is_sleeping — not the old five-key
+// stub (which also carried a stray "system_prompt" key the real endpoint does not have).
+func TestPropsKeySetMatchesDocumentedShape(t *testing.T) {
+	body := do(t, "GET", "/props", "").Body.String()
+	for _, key := range []string{
+		`"default_generation_settings"`, `"total_slots"`, `"model_path"`, `"chat_template"`,
+		`"chat_template_caps"`, `"modalities"`, `"media_marker"`, `"build_info"`, `"is_sleeping"`,
+	} {
+		if !strings.Contains(body, key) {
+			t.Errorf("/props missing documented key %s: %s", key, body)
+		}
+	}
+	if strings.Contains(body, `"system_prompt"`) {
+		t.Error(`/props still carries "system_prompt", which is not part of the real response`)
+	}
+	var resp struct {
+		DefaultGenerationSettings struct {
+			ID           int  `json:"id"`
+			IDTask       int  `json:"id_task"`
+			NCtx         int  `json:"n_ctx"`
+			IsProcessing bool `json:"is_processing"`
+			NextToken    struct {
+				HasNextToken bool `json:"has_next_token"`
+			} `json:"next_token"`
+		} `json:"default_generation_settings"`
+	}
+	if err := json.Unmarshal([]byte(body), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.DefaultGenerationSettings.NCtx != slotNCtx {
+		t.Errorf("default_generation_settings.n_ctx = %d, want %d", resp.DefaultGenerationSettings.NCtx, slotNCtx)
+	}
+}
+
+// POST /tokenize: {"tokens":[...]} by default, or [{"id","piece"}, ...] with with_pieces:true —
+// verified against tools/server/server-context.cpp's post_tokenize handler.
+func TestTokenize(t *testing.T) {
+	rec := do(t, "POST", "/tokenize", `{"content":"hello world"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var resp struct {
+		Tokens []int `json:"tokens"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal plain tokens: %v; body=%s", err, rec.Body.String())
+	}
+	if len(resp.Tokens) == 0 {
+		t.Fatal("no tokens returned")
+	}
+
+	rec = do(t, "POST", "/tokenize", `{"content":"hello world","with_pieces":true}`)
+	var piecesResp struct {
+		Tokens []struct {
+			ID    int    `json:"id"`
+			Piece string `json:"piece"`
+		} `json:"tokens"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &piecesResp); err != nil {
+		t.Fatalf("unmarshal with_pieces tokens: %v; body=%s", err, rec.Body.String())
+	}
+	if len(piecesResp.Tokens) == 0 {
+		t.Fatal("no tokens returned for with_pieces:true")
+	}
+	var rebuilt strings.Builder
+	for _, tok := range piecesResp.Tokens {
+		rebuilt.WriteString(tok.Piece)
+	}
+	if rebuilt.String() != "hello world" {
+		t.Errorf("pieces do not reconstruct the input: got %q, want %q", rebuilt.String(), "hello world")
+	}
+}
+
+// POST /detokenize: {"content": "..."} — verified against post_detokenize. We hold no real
+// vocabulary to reverse fabricated /tokenize ids through, so the honest answer is empty.
+func TestDetokenize(t *testing.T) {
+	rec := do(t, "POST", "/detokenize", `{"tokens":[1000,2000,3000]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var resp struct {
+		Content *string `json:"content"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.Content == nil {
+		t.Fatal(`"content" key missing from /detokenize response`)
+	}
+}
+
+// GET /slots: an array of slot objects, matching total_slots:1 from /props — verified against
+// get_slots / server_slot::to_json in server-context.cpp.
+func TestSlots(t *testing.T) {
+	rec := do(t, "GET", "/slots", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var slots []struct {
+		ID           int  `json:"id"`
+		NCtx         int  `json:"n_ctx"`
+		Speculative  bool `json:"speculative"`
+		IsProcessing bool `json:"is_processing"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &slots); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if len(slots) != 1 {
+		t.Fatalf("got %d slots, want 1 (matches /props total_slots)", len(slots))
+	}
+	if slots[0].NCtx != slotNCtx {
+		t.Errorf("slot n_ctx = %d, want %d", slots[0].NCtx, slotNCtx)
+	}
+	if slots[0].IsProcessing {
+		t.Error("a fresh slot must not be reported as processing")
+	}
+}
+
+// The capture middleware must see these new routes too, so attacker requests to them are
+// recorded rather than silently answered and dropped. isSignalPath already allowlists /slots,
+// /tokenize, /detokenize (llmcore/filter.go's exactSignalPaths) — this exercises the full
+// buildHandler() chain, not just the router, to confirm capture actually fires for them.
+func TestNewEndpointsAreCaptured(t *testing.T) {
+	orig := saveLlamacppRequest
+	t.Cleanup(func() { saveLlamacppRequest = orig })
+
+	var mu sync.Mutex
+	captured := map[string]bool{}
+	saveLlamacppRequest = func(req *proto.LlmRequest) error {
+		mu.Lock()
+		captured[req.Path] = true
+		mu.Unlock()
+		return nil
+	}
+
+	for _, tc := range []struct{ method, path, body string }{
+		{"POST", "/tokenize", `{"content":"hi"}`},
+		{"POST", "/detokenize", `{"tokens":[1]}`},
+		{"GET", "/slots", ""},
+	} {
+		var r *http.Request
+		if tc.body != "" {
+			r = httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+		} else {
+			r = httptest.NewRequest(tc.method, tc.path, nil)
+		}
+		rec := httptest.NewRecorder()
+		buildHandler().ServeHTTP(rec, r)
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s %s: status %d", tc.method, tc.path, rec.Code)
+		}
+	}
+
+	// Capture is async (fire-and-forget goroutine); give it a moment to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		n := len(captured)
+		mu.Unlock()
+		if n == 3 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, path := range []string{"/tokenize", "/detokenize", "/slots"} {
+		if !captured[path] {
+			t.Errorf("%s was not captured", path)
+		}
+	}
+}

--- a/llamacpp/llamacpp.go
+++ b/llamacpp/llamacpp.go
@@ -1,7 +1,9 @@
 package llamacpp
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -36,42 +38,71 @@ func (h *honeypot) Start() {
 	if port == "" {
 		port = defaultPort
 	}
-	handler := llmcore.Capture(saveLlamacppRequest)(cmdresp.MuxMiddleware("llamacpp")(newRouter()))
 	h.logger.Info().Str("port", port).Msg("starting llamacpp honeypot")
-	h.logger.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%s", port), handler)).Msg("failed to start")
+	h.logger.Fatal().Err(http.ListenAndServe(fmt.Sprintf(":%s", port), buildHandler())).Msg("failed to start")
 }
 
-// profile: llama.cpp's server is cpp-httplib, which appends "; charset=utf-8" to JSON.
-var profile = llmcore.Profile{DefaultModel: defaultModel, ContentType: llmcore.CTJSONCharset}
+// buildHandler composes the full middleware chain (capture + cmdresp override + routing), split
+// out from Start so tests can exercise it directly — matches the ollama/vllm packages' pattern.
+func buildHandler() http.Handler {
+	return llmcore.Capture(saveLlamacppRequest)(cmdresp.MuxMiddleware("llamacpp")(newRouter()))
+}
+
+// profile: llama.cpp's server is cpp-httplib, which appends "; charset=utf-8" to JSON on its
+// entire surface — unlike Ollama, where only the native /api/* routes get the charset and the
+// separate OpenAI-compat /v1/* layer does not. llama.cpp has no such split (one process, one
+// framework), so OpenAICompatContentType carries the same charset into /v1/chat/completions and
+// its error paths too. See llmcore/profile.go's CT* doc comment (threat_gg-5g1).
+var profile = llmcore.Profile{
+	DefaultModel:            defaultModel,
+	ContentType:             llmcore.CTJSONCharset,
+	OpenAICompatContentType: llmcore.CTJSONCharset,
+}
 
 func newRouter() http.Handler {
 	r := mux.NewRouter()
 	r.HandleFunc("/props", handleProps).Methods("GET")
 	r.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
-		llmcore.WriteJSON(w, http.StatusOK, map[string]any{"status": "ok"})
+		llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, map[string]any{"status": "ok"})
 	}).Methods("GET")
 	r.HandleFunc("/v1/models", handleModels).Methods("GET")
 	r.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, req *http.Request) {
 		llmcore.ChatCompletion(w, req, profile)
 	}).Methods("POST")
 	r.HandleFunc("/completion", handleCompletion).Methods("POST")
-	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		llmcore.WriteError(w, http.StatusNotFound, "Not Found", "invalid_request_error", "")
-	})
+	// threat_gg-5g1: /tokenize, /detokenize and /slots are standard llama-server endpoints,
+	// verified 404 on the live fleet. Shapes confirmed against the current server source
+	// (github.com/ggml-org/llama.cpp tools/server/server-context.cpp, post_tokenize/
+	// post_detokenize/get_slots handlers) — see endpoints.go.
+	r.HandleFunc("/tokenize", handleTokenize).Methods("POST")
+	r.HandleFunc("/detokenize", handleDetokenize).Methods("POST")
+	r.HandleFunc("/slots", handleSlots).Methods("GET")
+	r.PathPrefix("/").HandlerFunc(handleNotFound)
 	return r
 }
 
-func handleProps(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
-		"system_prompt":               "",
-		"default_generation_settings": map[string]any{"model": defaultModel, "n_ctx": 4096, "temperature": 0.8},
-		"total_slots":                 1,
-		"chat_template":               "{{ .System }}\n{{ .Prompt }}",
+// handleNotFound reproduces cpp-httplib's error_handler for unrouted paths: real llama.cpp
+// registers `srv->set_error_handler(...)` (server-http.cpp) which, for a 404, always writes this
+// exact envelope regardless of the route's own error shape — verified against
+// github.com/ggml-org/llama.cpp tools/server/server-http.cpp.
+func handleNotFound(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSONCT(w, http.StatusNotFound, llmcore.CTJSONCharset, notFoundBody{
+		Error: notFoundError{Message: "File Not Found", Type: "not_found_error", Code: http.StatusNotFound},
 	})
 }
 
+type notFoundError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Code    int    `json:"code"`
+}
+
+type notFoundBody struct {
+	Error notFoundError `json:"error"`
+}
+
 func handleModels(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, map[string]any{
 		"object": "list",
 		"data":   []map[string]any{{"id": defaultModel, "object": "model", "created": time.Now().Unix(), "owned_by": "llamacpp"}},
 	})
@@ -79,7 +110,7 @@ func handleModels(w http.ResponseWriter, r *http.Request) {
 
 // handleCompletion is llama.cpp's native (non-OpenAI) /completion endpoint.
 func handleCompletion(w http.ResponseWriter, r *http.Request) {
-	llmcore.WriteJSON(w, http.StatusOK, map[string]any{
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, map[string]any{
 		"content":             " Hello! How can I help you today?",
 		"id_slot":             0,
 		"stop":                true,
@@ -93,4 +124,12 @@ func handleCompletion(w http.ResponseWriter, r *http.Request) {
 		"stopped_limit":       false,
 		"id":                  uuid.NewV4().String(),
 	})
+}
+
+// readJSONBody parses a JSON object body into v, ignoring parse errors (an empty/absent v is
+// the harmless failure mode for these endpoints, matching how the rest of the package treats
+// malformed management-endpoint bodies).
+func readJSONBody(r *http.Request, v any) {
+	b, _ := io.ReadAll(io.LimitReader(r.Body, llmcore.MaxBodySize))
+	_ = json.Unmarshal(b, v)
 }

--- a/llamacpp/props.go
+++ b/llamacpp/props.go
@@ -1,0 +1,161 @@
+package llamacpp
+
+import (
+	"net/http"
+
+	"github.com/joshrendek/threat.gg-agent/llmcore"
+)
+
+// threat_gg-5g1: /props previously advertised chat_template as "{{ .System }}\n{{ .Prompt }}" —
+// Go text/template syntax, i.e. Ollama Modelfile format, on a llama.cpp endpoint. Real llama.cpp
+// surfaces the model's own chat template (read from the GGUF's tokenizer.chat_template
+// metadata), which for any GGUF converted from a Hugging Face chat model is Jinja2. The
+// replacement below is the actual published Llama-2-chat template from
+// meta-llama/Llama-2-7b-chat-hf's tokenizer_config.json, matching the model this honeypot
+// advertises (llama-2-7b-chat.Q4_K_M.gguf).
+//
+// The rest of the key set is verified against the current server docs:
+//
+//	github.com/ggml-org/llama.cpp tools/server/README.md, "GET /props: Get server global
+//	properties" — documents default_generation_settings{id,id_task,n_ctx,speculative,
+//	is_processing,params,prompt,next_token}, total_slots, model_path, chat_template,
+//	chat_template_caps, modalities, media_marker, build_info, is_sleeping. The default `params`
+//	values below are copied verbatim from that section's example response, since they are the
+//	server's stock sampling defaults rather than per-request state.
+//
+// (The current source additionally emits model_alias, model_ftype, endpoint_slots/props/metrics,
+// ui, ui_settings, bos_token, eos_token, cors_proxy_enabled — fields added after the README
+// section above was last written. They are left out here rather than guessed at; the README's
+// documented set is the citable, verified subset.)
+
+// slotNCtx is the per-slot context size advertised consistently across /props'
+// default_generation_settings, /completion's generation_settings, and /slots — a real server
+// would not contradict itself between these three endpoints.
+const slotNCtx = 4096
+
+// llama2ChatTemplate is copied from meta-llama/Llama-2-7b-chat-hf's tokenizer_config.json
+// "chat_template" field (the template Hugging Face's transformers and, downstream, llama.cpp's
+// GGUF conversion embed for this model family).
+const llama2ChatTemplate = `{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}{% else %}{% set loop_messages = messages %}{% set system_message = false %}{% endif %}{% for message in loop_messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% if loop.index0 == 0 and system_message != false %}{% set content = '<<SYS>>\n' + system_message + '\n<</SYS>>\n\n' + message['content'] %}{% else %}{% set content = message['content'] %}{% endif %}{% if message['role'] == 'user' %}{{ bos_token + '[INST] ' + content.strip() + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' '  + content.strip() + ' ' + eos_token }}{% endif %}{% endfor %}`
+
+// propsSamplingParams is the server's stock sampling defaults, field order and values copied
+// from the README's example response. Seed is int64: the documented default (4294967295, i.e.
+// uint32 max used as "no seed") overflows a 32-bit int, which this agent cross-compiles for
+// (armv6l/armv7l) — see the Makefile's arm targets.
+type propsSamplingParams struct {
+	NPredict            int      `json:"n_predict"`
+	Seed                int64    `json:"seed"`
+	Temperature         float64  `json:"temperature"`
+	DynatempRange       float64  `json:"dynatemp_range"`
+	DynatempExponent    float64  `json:"dynatemp_exponent"`
+	TopK                int      `json:"top_k"`
+	TopP                float64  `json:"top_p"`
+	MinP                float64  `json:"min_p"`
+	XTCProbability      float64  `json:"xtc_probability"`
+	XTCThreshold        float64  `json:"xtc_threshold"`
+	TypicalP            float64  `json:"typical_p"`
+	RepeatLastN         int      `json:"repeat_last_n"`
+	RepeatPenalty       float64  `json:"repeat_penalty"`
+	PresencePenalty     float64  `json:"presence_penalty"`
+	FrequencyPenalty    float64  `json:"frequency_penalty"`
+	DryMultiplier       float64  `json:"dry_multiplier"`
+	DryBase             float64  `json:"dry_base"`
+	DryAllowedLength    int      `json:"dry_allowed_length"`
+	DryPenaltyLastN     int      `json:"dry_penalty_last_n"`
+	DrySequenceBreakers []string `json:"dry_sequence_breakers"`
+	Mirostat            int      `json:"mirostat"`
+	MirostatTau         float64  `json:"mirostat_tau"`
+	MirostatEta         float64  `json:"mirostat_eta"`
+	Stop                []string `json:"stop"`
+	MaxTokens           int      `json:"max_tokens"`
+	NKeep               int      `json:"n_keep"`
+	NDiscard            int      `json:"n_discard"`
+	IgnoreEOS           bool     `json:"ignore_eos"`
+	Stream              bool     `json:"stream"`
+	NProbs              int      `json:"n_probs"`
+	MinKeep             int      `json:"min_keep"`
+	Grammar             string   `json:"grammar"`
+	Samplers            []string `json:"samplers"`
+	SpeculativeNMax     int      `json:"speculative.n_max"`
+	SpeculativeNMin     int      `json:"speculative.n_min"`
+	SpeculativePMin     float64  `json:"speculative.p_min"`
+	TimingsPerToken     bool     `json:"timings_per_token"`
+}
+
+func defaultSamplingParams() propsSamplingParams {
+	return propsSamplingParams{
+		NPredict: -1, Seed: 4294967295, Temperature: 0.800000011920929,
+		DynatempRange: 0, DynatempExponent: 1,
+		TopK: 40, TopP: 0.949999988079071, MinP: 0.05000000074505806,
+		XTCProbability: 0, XTCThreshold: 0.10000000149011612,
+		TypicalP: 1, RepeatLastN: 64, RepeatPenalty: 1,
+		PresencePenalty: 0, FrequencyPenalty: 0,
+		DryMultiplier: 0, DryBase: 1.75, DryAllowedLength: 2, DryPenaltyLastN: -1,
+		DrySequenceBreakers: []string{"\n", ":", "\"", "*"},
+		Mirostat:            0, MirostatTau: 5, MirostatEta: 0.10000000149011612,
+		Stop: []string{}, MaxTokens: -1, NKeep: 0, NDiscard: 0,
+		IgnoreEOS: false, Stream: true, NProbs: 0, MinKeep: 0, Grammar: "",
+		Samplers:        []string{"dry", "top_k", "typ_p", "top_p", "min_p", "xtc", "temperature"},
+		SpeculativeNMax: 16, SpeculativeNMin: 5, SpeculativePMin: 0.8999999761581421,
+		TimingsPerToken: false,
+	}
+}
+
+type propsNextToken struct {
+	HasNextToken bool   `json:"has_next_token"`
+	HasNewLine   bool   `json:"has_new_line"`
+	NRemain      int    `json:"n_remain"`
+	NDecoded     int    `json:"n_decoded"`
+	StoppingWord string `json:"stopping_word"`
+}
+
+type propsGenerationSettings struct {
+	ID           int                 `json:"id"`
+	IDTask       int                 `json:"id_task"`
+	NCtx         int                 `json:"n_ctx"`
+	Speculative  bool                `json:"speculative"`
+	IsProcessing bool                `json:"is_processing"`
+	Params       propsSamplingParams `json:"params"`
+	Prompt       string              `json:"prompt"`
+	NextToken    propsNextToken      `json:"next_token"`
+}
+
+// propsModalities intentionally carries only "vision": that is the field the README documents.
+// Current source also reports "video"/"audio", added after this section was last documented;
+// left out rather than guessed at.
+type propsModalities struct {
+	Vision bool `json:"vision"`
+}
+
+type propsResponse struct {
+	DefaultGenerationSettings propsGenerationSettings `json:"default_generation_settings"`
+	TotalSlots                int                     `json:"total_slots"`
+	ModelPath                 string                  `json:"model_path"`
+	ChatTemplate              string                  `json:"chat_template"`
+	ChatTemplateCaps          struct{}                `json:"chat_template_caps"`
+	Modalities                propsModalities         `json:"modalities"`
+	MediaMarker               string                  `json:"media_marker"`
+	BuildInfo                 string                  `json:"build_info"`
+	IsSleeping                bool                    `json:"is_sleeping"`
+}
+
+func handleProps(w http.ResponseWriter, r *http.Request) {
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSONCharset, propsResponse{
+		DefaultGenerationSettings: propsGenerationSettings{
+			ID: 0, IDTask: -1, NCtx: slotNCtx, Speculative: false, IsProcessing: false,
+			Params: defaultSamplingParams(),
+			Prompt: "",
+			NextToken: propsNextToken{
+				HasNextToken: true, HasNewLine: false, NRemain: -1, NDecoded: 0, StoppingWord: "",
+			},
+		},
+		TotalSlots:       1,
+		ModelPath:        "models/" + defaultModel,
+		ChatTemplate:     llama2ChatTemplate,
+		ChatTemplateCaps: struct{}{},
+		Modalities:       propsModalities{Vision: false},
+		MediaMarker:      "<__media__>",
+		BuildInfo:        "b4620-3f8e2a1",
+		IsSleeping:       false,
+	})
+}

--- a/llamacpp/tokencache.go
+++ b/llamacpp/tokencache.go
@@ -1,0 +1,168 @@
+package llamacpp
+
+import (
+	"hash/fnv"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// PR #33 review (ERROR 2): /detokenize used to answer every request with "" — including a
+// straight tokenize-then-detokenize probe of content it had itself just tokenized, which is
+// both a clean tell and simply wrong. /tokenize's ids used to be pure math/rand output
+// (llmcore.PseudoTokens), which cannot be reversed: nothing durable tied an id back to the text
+// it came from.
+//
+// The fix makes tokenization deterministic (idForPiece hashes the piece's own text, so identical
+// content always produces identical ids — a real tokenizer's property too) and remembers each
+// id -> piece mapping in a bounded, per-source-IP cache so /detokenize can look the pieces back
+// up and reconstruct the original text. Determinism alone would not be enough: a hash is one-way,
+// so recovering the text still requires *something* to have recorded it — this cache is that
+// something.
+//
+// Scoped and bounded per source IP for the same reason ollama/catalog.go's per-IP catalog views
+// are (#32, threat_gg-b57-adjacent): this honeypot is public and unauthenticated, so a single
+// shared, unbounded cache would let one attacker's flood of unique /tokenize calls evict another
+// attacker's just-issued tokens before they can be detokenized, and would grow without bound as
+// distinct callers arrive. Both axes are capped: distinct IPs tracked (maxTokenCacheViews) and
+// pieces remembered per IP (maxPiecesPerView), each evicted oldest-first.
+//
+// Trade-off: an attacker who tokenizes far more than maxPiecesPerView pieces in one call (or in
+// many calls without ever detokenizing) will find the earliest pieces already evicted by the time
+// they detokenize — the round trip degrades to partial reconstruction rather than failing
+// outright. That only affects pathological, unrealistic volumes; the realistic probe pattern this
+// fix targets is "tokenize a prompt, then immediately detokenize the ids it returned," which is
+// comfortably within the per-IP budget.
+
+const (
+	// maxTokenCacheViews caps how many distinct source IPs hold cached pieces, mirroring
+	// ollama/catalog.go's maxViews — without it, an attacker rotating source addresses could grow
+	// this map indefinitely.
+	maxTokenCacheViews = 256
+	// maxPiecesPerView caps how many token->piece mappings one IP can accumulate. A realistic
+	// tokenize/detokenize probe is a handful of calls over a few hundred tokens at most; this
+	// leaves generous headroom above that while still bounding memory per attacker.
+	maxPiecesPerView = 4096
+	// tokenCacheViewTTL expires an IP's cache entirely after this long without traffic from it.
+	tokenCacheViewTTL = time.Hour
+)
+
+// tokenCache is the per-source-IP id -> piece store described above.
+type tokenCache struct {
+	mu    sync.Mutex
+	views map[string]*tokenView
+}
+
+type tokenView struct {
+	byID  map[int]string
+	order []int // insertion order, oldest first, for bounded FIFO eviction
+	seen  time.Time
+}
+
+var tokenMemory = &tokenCache{views: map[string]*tokenView{}}
+
+// clientIP extracts the source address used to key the cache. Deliberately ignores
+// X-Forwarded-For, same reasoning as ollama/catalog.go's clientIP: this honeypot is addressed
+// directly, so an attacker-supplied header would let one caller read or evict another's cache.
+func clientIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+// remember records that id decodes to piece for this source IP, evicting the oldest entry (view
+// or, within a view, piece) when a bound would otherwise be exceeded.
+func (c *tokenCache) remember(ip string, id int, piece string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for k, v := range c.views {
+		if now.Sub(v.seen) > tokenCacheViewTTL {
+			delete(c.views, k)
+		}
+	}
+
+	v, ok := c.views[ip]
+	if !ok {
+		if len(c.views) >= maxTokenCacheViews {
+			var oldestKey string
+			var oldest time.Time
+			for k, vv := range c.views {
+				if oldestKey == "" || vv.seen.Before(oldest) {
+					oldestKey, oldest = k, vv.seen
+				}
+			}
+			delete(c.views, oldestKey)
+		}
+		v = &tokenView{byID: map[int]string{}}
+		c.views[ip] = v
+	}
+	v.seen = now
+
+	if _, exists := v.byID[id]; !exists {
+		if len(v.order) >= maxPiecesPerView {
+			oldestID := v.order[0]
+			v.order = v.order[1:]
+			delete(v.byID, oldestID)
+		}
+		v.order = append(v.order, id)
+	}
+	v.byID[id] = piece
+}
+
+// lookup returns the piece previously remembered for id under this source IP, if any is still
+// cached.
+func (c *tokenCache) lookup(ip string, id int) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.views[ip]
+	if !ok {
+		return "", false
+	}
+	piece, ok := v.byID[id]
+	return piece, ok
+}
+
+// tokenCountFor mirrors llmcore's private estTokens heuristic (~4 chars/token, floor 1) — not
+// shared, since llama.cpp needs the count without llmcore.PseudoTokens' random values or its
+// Ollama-flavoured BOS handling.
+func tokenCountFor(content string) int {
+	n := len(content) / 4
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// idForPiece derives a stable, plausible-looking token id from a piece's own text: the same piece
+// text always hashes to the same id (so two different requests that happen to tokenize the same
+// substring, e.g. a common word, land on the same id — as a real shared vocabulary would too),
+// and the range matches what llmcore.PseudoTokens already advertises elsewhere on this surface.
+func idForPiece(piece string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(piece))
+	return 1000 + int(h.Sum32()%126000)
+}
+
+// deterministicTokens splits content the same way with_pieces already did (splitIntoChunks),
+// derives each piece's id, and records the id -> piece mapping for ip so a later /detokenize call
+// from the same source can reconstruct it. Returns the ids and their corresponding piece texts in
+// order; concatenating pieces reproduces content exactly (splitIntoChunks partitions the input
+// without gaps or overlap).
+func deterministicTokens(content string, ip string) (ids []int, pieces []string) {
+	n := tokenCountFor(content)
+	pieces = splitIntoChunks(content, n)
+	ids = make([]int, n)
+	for i, piece := range pieces {
+		id := idForPiece(piece)
+		ids[i] = id
+		tokenMemory.remember(ip, id, piece)
+	}
+	return ids, pieces
+}

--- a/llamacpp/tokencache_test.go
+++ b/llamacpp/tokencache_test.go
@@ -1,0 +1,145 @@
+package llamacpp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for the PR #33 review's per-source-IP scoping requirement on ERROR 2's fix
+// (mirrors ollama/catalog_isolation_test.go's coverage of the same lesson from #32).
+
+func doFrom(t *testing.T, ip, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	r.RemoteAddr = ip + ":54321"
+	rec := httptest.NewRecorder()
+	newRouter().ServeHTTP(rec, r)
+	return rec
+}
+
+func tokenizeIDs(t *testing.T, ip, content string) []int {
+	t.Helper()
+	var resp struct {
+		Tokens []int `json:"tokens"`
+	}
+	body := doFrom(t, ip, "POST", "/tokenize", fmt.Sprintf(`{"content":%q}`, content)).Body.Bytes()
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("tokenize for %s: %v — %s", ip, err, body)
+	}
+	return resp.Tokens
+}
+
+func detokenizeFrom(t *testing.T, ip string, ids []int) string {
+	t.Helper()
+	idsJSON, err := json.Marshal(ids)
+	if err != nil {
+		t.Fatalf("marshal ids: %v", err)
+	}
+	var resp struct {
+		Content string `json:"content"`
+	}
+	body := doFrom(t, ip, "POST", "/detokenize", fmt.Sprintf(`{"tokens":%s}`, idsJSON)).Body.Bytes()
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("detokenize for %s: %v — %s", ip, err, body)
+	}
+	return resp.Content
+}
+
+// One attacker's tokenize/detokenize traffic must not let a different source reconstruct it —
+// the cache is per-IP, not global, exactly as ollama/catalog.go's overlay views are.
+func TestDetokenizeDoesNotLeakAcrossCallers(t *testing.T) {
+	const owner, other = "203.0.113.7", "198.51.100.9"
+	const secret = "the attacker's own prompt text"
+
+	ids := tokenizeIDs(t, owner, secret)
+	if len(ids) == 0 {
+		t.Fatal("no tokens returned")
+	}
+
+	if got := detokenizeFrom(t, owner, ids); got != secret {
+		t.Errorf("owner round trip failed: got %q, want %q", got, secret)
+	}
+	if got := detokenizeFrom(t, other, ids); got != "" {
+		t.Errorf("a different source IP recovered another caller's text: %q", got)
+	}
+}
+
+// X-Forwarded-For is attacker-controlled on a directly-addressed honeypot; honouring it would let
+// one caller read another caller's cached pieces by spoofing their address.
+func TestForwardedHeaderDoesNotKeyTheTokenCache(t *testing.T) {
+	const victim = "198.51.100.88"
+	const text = "victim only text"
+	ids := tokenizeIDs(t, victim, text)
+
+	r := httptest.NewRequest("POST", "/detokenize", strings.NewReader(fmt.Sprintf(`{"tokens":%s}`, mustJSON(t, ids))))
+	r.RemoteAddr = "203.0.113.99:1111"
+	r.Header.Set("X-Forwarded-For", victim)
+	rec := httptest.NewRecorder()
+	newRouter().ServeHTTP(rec, r)
+
+	var resp struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.Content == text {
+		t.Error("X-Forwarded-For let a spoofed caller read the victim's cached tokens")
+	}
+}
+
+// Rotating source addresses must not grow the per-IP view map without bound.
+func TestTokenCacheViewsAreBounded(t *testing.T) {
+	for i := 0; i < maxTokenCacheViews+64; i++ {
+		ip := fmt.Sprintf("10.%d.%d.%d", i/65536%256, i/256%256, i%256)
+		tokenizeIDs(t, ip, "flood")
+	}
+	tokenMemory.mu.Lock()
+	n := len(tokenMemory.views)
+	tokenMemory.mu.Unlock()
+	if n > maxTokenCacheViews {
+		t.Errorf("token cache holds %d views, cap is %d", n, maxTokenCacheViews)
+	}
+}
+
+// Tokenizing far more content than one IP's piece budget must not grow that IP's cache entry
+// without bound — old pieces are evicted to make room, which is why an extreme volume degrades
+// to partial reconstruction rather than failing outright (see tokencache.go's trade-off comment).
+func TestTokenCachePiecesPerViewAreBounded(t *testing.T) {
+	const ip = "203.0.113.40"
+	// Needs high piece-to-piece variety, not just length: splitIntoChunks slices contiguously, so
+	// a short repeating pattern (e.g. "word word word...") cycles through only a handful of
+	// distinct 4-char windows and would never actually exercise eviction. A long run of
+	// concatenated increasing integers has no short period, so its contiguous windows are
+	// overwhelmingly distinct.
+	var b strings.Builder
+	for i := 0; i < maxPiecesPerView*8; i++ {
+		fmt.Fprintf(&b, "%d", i)
+	}
+	tokenizeIDs(t, ip, b.String())
+
+	tokenMemory.mu.Lock()
+	n := len(tokenMemory.views[ip].byID)
+	tokenMemory.mu.Unlock()
+	if n > maxPiecesPerView {
+		t.Errorf("view holds %d cached pieces, cap is %d", n, maxPiecesPerView)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/llmcore/filter.go
+++ b/llmcore/filter.go
@@ -17,7 +17,7 @@ var apiSignalSegments = map[string]bool{
 // (llama.cpp /props /completion /slots, vLLM /health /metrics, ComfyUI /system_stats /prompt,
 // LocalAI /models /readyz, Ray /nodes, …).
 var exactSignalPaths = map[string]bool{
-	"/models": true, "/props": true, "/health": true, "/readyz": true,
+	"/models": true, "/props": true, "/health": true, "/healthz": true, "/readyz": true,
 	"/metrics": true, "/version": true, "/slots": true, "/completion": true,
 	"/completions": true, "/tokenize": true, "/detokenize": true,
 	"/embedding": true, "/infill": true, "/system_stats": true,
@@ -44,6 +44,13 @@ func isSignalPath(path string) bool {
 			seg = seg[:i]
 		}
 		return apiSignalSegments[seg]
+	}
+	// ComfyUI's /history/{prompt_id} carries a path parameter, so it needs a prefix check
+	// rather than the exact-match table: a hit here means an attacker submitted a workflow via
+	// /prompt and is polling for its result, which is exactly the signal /history itself is kept
+	// for.
+	if strings.HasPrefix(p, "/history/") {
+		return true
 	}
 	return exactSignalPaths[p]
 }

--- a/llmcore/filter_test.go
+++ b/llmcore/filter_test.go
@@ -16,8 +16,9 @@ func TestIsSignalPath(t *testing.T) {
 		"/v1/responses", // new OpenAI Responses API — caught by the /v1/ rule
 		"/api/tags", "/api/generate", "/api/chat", "/api/version", "/api/ps",
 		"/api/show", "/api/pull", "/api/embeddings", "/api/jobs/", "/api/jobs/raysubmit_x",
-		"/api/cluster_status", "/models", "/props", "/health", "/readyz", "/metrics",
-		"/completion", "/tokenize", "/system_stats", "/object_info", "/queue", "/prompt",
+		"/api/cluster_status", "/models", "/props", "/health", "/healthz", "/readyz", "/metrics",
+		"/completion", "/tokenize", "/detokenize", "/slots", "/system_stats", "/object_info",
+		"/queue", "/prompt", "/history", "/history/abc-123-uuid",
 		"/nodes", "/v1/models/", // trailing slash tolerated
 	}
 	for _, p := range signal {

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -174,6 +174,7 @@ func promptText(body []byte) string {
 	var m struct {
 		Prompt   string `json:"prompt"`
 		Input    string `json:"input"`
+		Content  string `json:"content"` // llama.cpp's /tokenize and /completion use "content".
 		Messages []struct {
 			Content string `json:"content"`
 		} `json:"messages"`
@@ -184,6 +185,9 @@ func promptText(body []byte) string {
 	}
 	if m.Input != "" {
 		return m.Input
+	}
+	if m.Content != "" {
+		return m.Content
 	}
 	if len(m.Messages) > 0 {
 		return m.Messages[len(m.Messages)-1].Content
@@ -345,7 +349,7 @@ func ChatCompletion(w http.ResponseWriter, r *http.Request, p Profile) {
 	}
 
 	pt := promptTokensFor(promptText(body))
-	WriteJSONCT(w, http.StatusOK, CTJSON, openAIChatResponse{
+	WriteJSONCT(w, http.StatusOK, p.openAICT(), openAIChatResponse{
 		ID: id, Object: "chat.completion", Created: created, Model: model,
 		SystemFingerprint: p.SystemFingerprint,
 		Choices: []openAIChatChoice{{
@@ -371,7 +375,7 @@ func Completion(w http.ResponseWriter, r *http.Request, p Profile) {
 	}
 	reply, chunks, finish := capReply(smartReply(promptText(body)), maxTokensOf(body))
 	pt := promptTokensFor(promptText(body))
-	WriteJSONCT(w, http.StatusOK, CTJSON, openAITextResponse{
+	WriteJSONCT(w, http.StatusOK, p.openAICT(), openAITextResponse{
 		ID: completionID(p, "cmpl"), Object: "text_completion",
 		Created: time.Now().Unix(), Model: model,
 		SystemFingerprint: p.SystemFingerprint,

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -174,7 +174,7 @@ func promptText(body []byte) string {
 	var m struct {
 		Prompt   string `json:"prompt"`
 		Input    string `json:"input"`
-		Content  string `json:"content"` // llama.cpp's /tokenize and /completion use "content".
+		Content  string `json:"content"` // llama.cpp's /tokenize request uses "content" (/completion's request field is "prompt"; "content" there names the response field instead).
 		Messages []struct {
 			Content string `json:"content"`
 		} `json:"messages"`

--- a/llmcore/profile.go
+++ b/llmcore/profile.go
@@ -37,6 +37,14 @@ type Profile struct {
 	// scoped per source IP. A global catalog would let one anonymous caller delete the
 	// advertised models and disarm the honeypot for everyone.
 	KnownModel func(r *http.Request, model string) bool
+	// OpenAICompatContentType overrides the content type used by the shared OpenAI-compatible
+	// generators (ChatCompletion, Completion) and their error paths. Empty defaults to bare
+	// CTJSON, which is correct for Ollama and vLLM: their /v1/* layer is served by a different
+	// framework than their native routes and never adds a charset (see the CT* comment above).
+	// llama.cpp is the exception — its entire surface, native and OpenAI-compat alike, is one
+	// cpp-httplib process, so /v1/* gets the same "; charset=utf-8" as everything else; its
+	// profile sets this field to CTJSONCharset accordingly.
+	OpenAICompatContentType string
 }
 
 func (p Profile) ct() string {
@@ -44,6 +52,13 @@ func (p Profile) ct() string {
 		return CTJSON
 	}
 	return p.ContentType
+}
+
+func (p Profile) openAICT() string {
+	if p.OpenAICompatContentType == "" {
+		return CTJSON
+	}
+	return p.OpenAICompatContentType
 }
 
 // known reports whether model is servable for this requester.
@@ -80,9 +95,11 @@ type ollamaErrorEnvelope struct {
 
 // WriteOpenAIError writes the OpenAI error envelope used by /v1/* surfaces:
 // {"error":{"message":…,"type":…,"param":null,"code":null}}. Matches Ollama's OpenAI-compat
-// layer byte-for-byte, including the explicit nulls and their position.
+// layer byte-for-byte, including the explicit nulls and their position. The content type is
+// per-profile (see Profile.OpenAICompatContentType) rather than a bare CTJSON constant, since
+// llama.cpp's /v1/* layer carries the same charset as the rest of its surface.
 func WriteOpenAIError(w http.ResponseWriter, p Profile, status int, message, errType string) {
-	w.Header().Set("Content-Type", CTJSON)
+	w.Header().Set("Content-Type", p.openAICT())
 	w.WriteHeader(status)
 	writeCompactJSON(w, openAIErrorEnvelope{Error: openAIErrorBody{Message: message, Type: errType}})
 }

--- a/llmcore/profile_test.go
+++ b/llmcore/profile_test.go
@@ -1,0 +1,34 @@
+package llmcore
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// Regression coverage for the PR #33 review: the charset fix (Profile.OpenAICompatContentType)
+// only had success-path coverage. WriteOpenAIError is the shared error writer for every
+// OpenAI-compat surface (malformed JSON, unknown model, embeddings refusals, …), so its content
+// type must track the same per-profile rule as the success path.
+
+// A profile that sets OpenAICompatContentType (llama.cpp's shape) must carry that charset on its
+// error path too, not just on a successful completion.
+func TestWriteOpenAIErrorHonoursOpenAICompatContentType(t *testing.T) {
+	p := Profile{OpenAICompatContentType: CTJSONCharset}
+	rec := httptest.NewRecorder()
+	WriteOpenAIError(rec, p, 400, "bad request", "invalid_request_error")
+	if got := rec.Header().Get("Content-Type"); got != CTJSONCharset {
+		t.Errorf("content-type = %q, want %q", got, CTJSONCharset)
+	}
+}
+
+// A profile that leaves OpenAICompatContentType unset (Ollama and vLLM) must keep the bare,
+// no-charset content type on its error path — this is the pre-existing, already-verified
+// behaviour, and the new field must not regress it.
+func TestWriteOpenAIErrorDefaultsToBareJSON(t *testing.T) {
+	p := Profile{}
+	rec := httptest.NewRecorder()
+	WriteOpenAIError(rec, p, 404, "model not found", "not_found_error")
+	if got := rec.Header().Get("Content-Type"); got != CTJSON {
+		t.Errorf("content-type = %q, want bare %q", got, CTJSON)
+	}
+}

--- a/llmcore/responses.go
+++ b/llmcore/responses.go
@@ -123,14 +123,18 @@ func PseudoTokens(text string) []int {
 	return out
 }
 
-// WriteEmbeddingsUnsupported reproduces the 501 a real Ollama returns when the requested model
-// has no embedding support — which is true of every model in the advertised catalog. Fabricating
-// a plausible embedding vector would be more work and less accurate than the real refusal.
-func WriteEmbeddingsUnsupported(w http.ResponseWriter, p Profile, openAIShape bool) {
+// WriteEmbeddingsUnsupported reproduces the refusal a real Ollama returns when the requested
+// model has no embedding support — which is true of every model in the advertised catalog.
+// Fabricating a plausible embedding vector would be more work and less accurate than the real
+// refusal. The message is identical everywhere (Ollama embeds llama.cpp and surfaces its error
+// verbatim); the status code is not — measured against a real Ollama 0.30.11 (threat_gg-5fb):
+// POST /api/embed -> 501, POST /api/embeddings -> 500, POST /v1/embeddings -> 501. Callers pass
+// the status that matches their route rather than this function picking one for all of them.
+func WriteEmbeddingsUnsupported(w http.ResponseWriter, p Profile, status int, openAIShape bool) {
 	const msg = "This server does not support embeddings. Start it with `--embeddings`"
 	if openAIShape {
-		WriteOpenAIError(w, p, http.StatusNotImplemented, msg, "api_error")
+		WriteOpenAIError(w, p, status, msg, "api_error")
 		return
 	}
-	WriteOllamaError(w, p, http.StatusNotImplemented, msg)
+	WriteOllamaError(w, p, status, msg)
 }

--- a/llmcore/responses.go
+++ b/llmcore/responses.go
@@ -83,7 +83,7 @@ func Responses(w http.ResponseWriter, r *http.Request, p Profile) {
 	now := time.Now().Unix()
 	in := promptTokensFor(prompt)
 
-	WriteJSONCT(w, http.StatusOK, CTJSON, responsesPayload{
+	WriteJSONCT(w, http.StatusOK, p.openAICT(), responsesPayload{
 		ID:        fmt.Sprintf("resp_%d", rand.Intn(100000)),
 		Object:    "response",
 		CreatedAt: now, CompletedAt: now,
@@ -107,8 +107,8 @@ func Responses(w http.ResponseWriter, r *http.Request, p Profile) {
 	})
 }
 
-// PromptOf returns the prompt/input text from a request body, for surfaces that need it outside
-// the generators (vLLM's /tokenize, for instance).
+// PromptOf returns the prompt/input/content text from a request body, for surfaces that need it
+// outside the generators (vLLM's and llama.cpp's /tokenize, for instance).
 func PromptOf(r *http.Request) string { return promptText(readBody(r)) }
 
 // PseudoTokens produces a plausible token-id sequence for text. Used by /tokenize, where the

--- a/localai/embeddings.go
+++ b/localai/embeddings.go
@@ -1,0 +1,143 @@
+package localai
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/llmcore"
+	uuid "github.com/satori/go.uuid"
+)
+
+// threat_gg-3kd: POST /v1/embeddings verified 404 on the live fleet. Embeddings are a headline
+// LocalAI feature (not a refusal, unlike Ollama/vLLM — see llmcore.WriteEmbeddingsUnsupported and
+// vllm's handleEmbeddings), so a 404 here is a tell. Response shape verified against the current
+// source:
+//
+//	github.com/mudler/LocalAI core/http/endpoints/openai/embeddings.go (EmbeddingsEndpoint)
+//	  + core/schema/openai.go (OpenAIResponse, Item, Item.MarshalJSON)
+//
+// Confirmed from that source: the response echoes the caller's own "model" string verbatim
+// (LocalAI's comment: "we have to return what the user sent here, due to OpenAI spec"), omits
+// "usage" and "choices" entirely (both are nil *pointer-or-slice `omitempty` fields on this
+// path), and supports encoding_format:"base64" — the Node.js OpenAI SDK (v4+) sends that by
+// default. floatsToBase64 below is the same little-endian float32-packing scheme as the real
+// server's helper of the same name.
+//
+// A missing "model" fails the same way real LocalAI does: EmbeddingsEndpoint returns
+// echo.ErrBadRequest, and Echo's DefaultHTTPErrorHandler renders that as {"message":"Bad
+// Request"} with a bare "application/json" content type (github.com/labstack/echo/v4 echo.go,
+// DefaultHTTPErrorHandler + the MIMEApplicationJSON constant, which — confirmed from the same
+// source — is unsuffixed even though LocalAI has migrated off Fiber onto Echo; the "no charset"
+// assumption this package's profile already encodes still holds).
+//
+// Not reproduced: the actual embedding values are fabricated (no real model backs this
+// honeypot), and only the plain-string/array-of-strings "input" shapes are parsed — the
+// less common array-of-token-ids form is not.
+
+// embeddingDims is a plausible embedding width: OpenAI's text-embedding-ada-002, the dimension
+// most embedding-consuming client code is written against.
+const embeddingDims = 1536
+
+type embeddingsRequest struct {
+	Model          string          `json:"model"`
+	Input          json.RawMessage `json:"input"`
+	EncodingFormat string          `json:"encoding_format"`
+}
+
+// embeddingInputs accepts either a single string or an array of strings — the two shapes the
+// OpenAI embeddings API allows for "input" that a real client actually sends.
+func embeddingInputs(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var single string
+	if err := json.Unmarshal(raw, &single); err == nil {
+		return []string{single}
+	}
+	var multi []string
+	if err := json.Unmarshal(raw, &multi); err == nil {
+		return multi
+	}
+	return nil
+}
+
+// fakeEmbedding fabricates a plausible-looking unit-scale vector. No real model backs this
+// honeypot, so the values themselves carry no meaning; only their shape (length, magnitude) is
+// checked by any real client.
+func fakeEmbedding(dims int) []float32 {
+	out := make([]float32, dims)
+	for i := range out {
+		out[i] = rand.Float32()*2 - 1
+	}
+	return out
+}
+
+// floatsToBase64 packs a float32 slice as little-endian bytes and base64-encodes it — the same
+// encoding real LocalAI uses for encoding_format:"base64" (core/http/endpoints/openai/embeddings.go).
+func floatsToBase64(floats []float32) string {
+	buf := make([]byte, len(floats)*4)
+	for i, f := range floats {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(f))
+	}
+	return base64.StdEncoding.EncodeToString(buf)
+}
+
+type embeddingItem struct {
+	Embedding any    `json:"embedding"`
+	Index     int    `json:"index"`
+	Object    string `json:"object"`
+}
+
+type embeddingsResponse struct {
+	Created int64           `json:"created"`
+	Object  string          `json:"object"`
+	ID      string          `json:"id"`
+	Model   string          `json:"model"`
+	Data    []embeddingItem `json:"data"`
+}
+
+type echoErrorBody struct {
+	Message string `json:"message"`
+}
+
+func handleEmbeddings(w http.ResponseWriter, r *http.Request) {
+	var req embeddingsRequest
+	b, _ := io.ReadAll(io.LimitReader(r.Body, llmcore.MaxBodySize))
+	_ = json.Unmarshal(b, &req)
+
+	if req.Model == "" {
+		llmcore.WriteJSONCT(w, http.StatusBadRequest, llmcore.CTJSON, echoErrorBody{Message: "Bad Request"})
+		return
+	}
+
+	inputs := embeddingInputs(req.Input)
+	if len(inputs) == 0 {
+		inputs = []string{""}
+	}
+
+	data := make([]embeddingItem, len(inputs))
+	for i := range inputs {
+		vec := fakeEmbedding(embeddingDims)
+		item := embeddingItem{Index: i, Object: "embedding"}
+		if req.EncodingFormat == "base64" {
+			item.Embedding = floatsToBase64(vec)
+		} else {
+			item.Embedding = vec
+		}
+		data[i] = item
+	}
+
+	llmcore.WriteJSONCT(w, http.StatusOK, llmcore.CTJSON, embeddingsResponse{
+		Created: time.Now().Unix(),
+		Object:  "list",
+		ID:      uuid.NewV4().String(),
+		Model:   req.Model,
+		Data:    data,
+	})
+}

--- a/localai/embeddings.go
+++ b/localai/embeddings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math"
 	"math/rand"
@@ -43,6 +44,30 @@ import (
 // embeddingDims is a plausible embedding width: OpenAI's text-embedding-ada-002, the dimension
 // most embedding-consuming client code is written against.
 const embeddingDims = 1536
+
+// PR #33 review (two independent reviewers): the request body is capped at 1MB
+// (llmcore.MaxBodySize), but nothing capped how many items "input" could contain. Each item's
+// output cost (fakeEmbedding's embeddingDims-length vector, then its JSON serialization) is
+// fixed regardless of how short that item's own string was, so a 1MB array of one-character
+// strings — hundreds of thousands of items — turns into gigabytes of allocation and CPU from a
+// single request to a public, unauthenticated honeypot.
+//
+// maxEmbeddingItems is picked to look like a real batch, not to be the largest tolerable number:
+// embedding clients (LangChain, llama-index, the OpenAI SDKs) default to batching in the tens,
+// not thousands, so a legitimate caller never notices this cap. maxEmbeddingOutputFloats is the
+// same budget re-expressed as total floats and checked independently, before any vector is
+// allocated — currently a restatement of maxEmbeddingItems given a fixed embeddingDims, but it
+// stays correct on its own if a future change ever makes per-item width vary.
+//
+// Checked, per the review's request: vLLM's and Ollama's embeddings paths only ever write a
+// fixed refusal (llmcore.WriteEmbeddingsUnsupported / vllm's handleEmbeddings) without parsing
+// "input" or allocating per item at all, so they cannot amplify this way. llama.cpp implements no
+// embeddings endpoint. LocalAI is the only product here that actually fabricates a vector per
+// input item.
+const (
+	maxEmbeddingItems        = 64
+	maxEmbeddingOutputFloats = maxEmbeddingItems * embeddingDims
+)
 
 type embeddingsRequest struct {
 	Model          string          `json:"model"`
@@ -119,6 +144,19 @@ func handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 	inputs := embeddingInputs(req.Input)
 	if len(inputs) == 0 {
 		inputs = []string{""}
+	}
+
+	// Reject an oversized batch outright rather than silently truncating it — truncating would
+	// itself be a tell (the returned item count would not match what the caller sent). Real
+	// LocalAI has no known explicit batch-size check of its own (it would just try to process
+	// whatever it was given), so this message is invented rather than sourced; it reuses the same
+	// Echo-style {"message":...} 400 shape this endpoint already uses for a missing model, since
+	// that is this product's one verified error convention rather than a second, inconsistent one.
+	if len(inputs) > maxEmbeddingItems || len(inputs)*embeddingDims > maxEmbeddingOutputFloats {
+		llmcore.WriteJSONCT(w, http.StatusBadRequest, llmcore.CTJSON, echoErrorBody{
+			Message: fmt.Sprintf("batch size %d exceeds the maximum of %d inputs per request", len(inputs), maxEmbeddingItems),
+		})
+		return
 	}
 
 	data := make([]embeddingItem, len(inputs))

--- a/localai/fidelity_test.go
+++ b/localai/fidelity_test.go
@@ -1,0 +1,135 @@
+package localai
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression tests for threat_gg-3kd.
+
+func do(t *testing.T, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	rec := httptest.NewRecorder()
+	newRouter().ServeHTTP(rec, r)
+	return rec
+}
+
+// Real LocalAI exposes /healthz and /readyz side by side (core/http/routes/health.go), both a
+// bare 200 with no body.
+func TestHealthzMatchesReadyz(t *testing.T) {
+	for _, path := range []string{"/healthz", "/readyz"} {
+		rec := do(t, "GET", path, "")
+		if rec.Code != http.StatusOK {
+			t.Errorf("%s: status %d, want 200", path, rec.Code)
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("%s: body %q, want empty", path, rec.Body.String())
+		}
+	}
+}
+
+// POST /v1/embeddings must return the OpenAI embeddings shape, not a 404 — embeddings are a
+// headline LocalAI feature. Shape verified against core/http/endpoints/openai/embeddings.go +
+// core/schema/openai.go (see embeddings.go's source comment).
+func TestEmbeddingsReturnsOpenAIShape(t *testing.T) {
+	rec := do(t, "POST", "/v1/embeddings", `{"model":"text-embedding-ada-002","input":"hello world"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type %q, want bare application/json", got)
+	}
+	var resp struct {
+		Object string `json:"object"`
+		Model  string `json:"model"`
+		Data   []struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+			Object    string    `json:"object"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.Object != "list" {
+		t.Errorf("object = %q, want list", resp.Object)
+	}
+	// LocalAI echoes the caller's own model string verbatim, not a normalised/default one.
+	if resp.Model != "text-embedding-ada-002" {
+		t.Errorf("model = %q, want echoed back verbatim", resp.Model)
+	}
+	if len(resp.Data) != 1 || resp.Data[0].Object != "embedding" || len(resp.Data[0].Embedding) != embeddingDims {
+		t.Errorf("data shape wrong: %+v", resp.Data)
+	}
+	if strings.Contains(rec.Body.String(), `"usage"`) || strings.Contains(rec.Body.String(), `"choices"`) {
+		t.Errorf("embeddings response must omit usage/choices: %s", rec.Body.String())
+	}
+}
+
+// Multiple strings in "input" produce one embedding item per string, index in order.
+func TestEmbeddingsMultipleInputs(t *testing.T) {
+	rec := do(t, "POST", "/v1/embeddings", `{"model":"m","input":["a","b","c"]}`)
+	var resp struct {
+		Data []struct {
+			Index int `json:"index"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if len(resp.Data) != 3 {
+		t.Fatalf("got %d items, want 3", len(resp.Data))
+	}
+	for i, item := range resp.Data {
+		if item.Index != i {
+			t.Errorf("item %d has index %d", i, item.Index)
+		}
+	}
+}
+
+// encoding_format:"base64" packs the vector as a base64 string instead of a float array — the
+// Node.js OpenAI SDK (v4+) sends this by default.
+func TestEmbeddingsBase64Format(t *testing.T) {
+	rec := do(t, "POST", "/v1/embeddings", `{"model":"m","input":"hi","encoding_format":"base64"}`)
+	var resp struct {
+		Data []struct {
+			Embedding string `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("got %d items, want 1", len(resp.Data))
+	}
+	raw, err := base64.StdEncoding.DecodeString(resp.Data[0].Embedding)
+	if err != nil {
+		t.Fatalf("embedding is not valid base64: %v", err)
+	}
+	if len(raw) != embeddingDims*4 {
+		t.Errorf("decoded %d bytes, want %d (dims * 4 bytes/float32)", len(raw), embeddingDims*4)
+	}
+}
+
+// Real LocalAI (EmbeddingsEndpoint) rejects a request with no model via echo.ErrBadRequest,
+// which Echo's DefaultHTTPErrorHandler renders as {"message":"Bad Request"} — not the OpenAI
+// error envelope this package's chat/completions error path uses.
+func TestEmbeddingsMissingModelIsBadRequest(t *testing.T) {
+	rec := do(t, "POST", "/v1/embeddings", `{"input":"hi"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"message":"Bad Request"}` {
+		t.Errorf("body %q, want %q", got, `{"message":"Bad Request"}`)
+	}
+}

--- a/localai/fidelity_test.go
+++ b/localai/fidelity_test.go
@@ -132,4 +132,61 @@ func TestEmbeddingsMissingModelIsBadRequest(t *testing.T) {
 	if got := strings.TrimSpace(rec.Body.String()); got != `{"message":"Bad Request"}` {
 		t.Errorf("body %q, want %q", got, `{"message":"Bad Request"}`)
 	}
+	// Echo's JSON content type is bare, even though LocalAI has migrated off Fiber onto Echo —
+	// see embeddings.go's source comment.
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type %q, want bare application/json", got)
+	}
+}
+
+// PR #33 review (ERROR 1): a batch bigger than maxEmbeddingItems must be rejected before any
+// vector is allocated for it, not silently truncated to the cap.
+func TestEmbeddingsOversizedBatchIsRejected(t *testing.T) {
+	inputs := make([]string, maxEmbeddingItems+1)
+	for i := range inputs {
+		inputs[i] = "x"
+	}
+	body, err := json.Marshal(map[string]any{"model": "m", "input": inputs})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := do(t, "POST", "/v1/embeddings", string(body))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rec.Code)
+	}
+	var resp struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if resp.Message == "" {
+		t.Error("oversized-batch response has no message")
+	}
+}
+
+// A batch at exactly the cap must still succeed — the limit rejects what is over budget, not
+// what is at it.
+func TestEmbeddingsBatchAtCapSucceeds(t *testing.T) {
+	inputs := make([]string, maxEmbeddingItems)
+	for i := range inputs {
+		inputs[i] = "x"
+	}
+	body, err := json.Marshal(map[string]any{"model": "m", "input": inputs})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := do(t, "POST", "/v1/embeddings", string(body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Data []struct{} `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, rec.Body.String())
+	}
+	if len(resp.Data) != maxEmbeddingItems {
+		t.Errorf("got %d items, want %d", len(resp.Data), maxEmbeddingItems)
+	}
 }

--- a/localai/localai.go
+++ b/localai/localai.go
@@ -54,6 +54,13 @@ func newRouter() http.Handler {
 		llmcore.Completion(w, req, profile)
 	}).Methods("POST")
 	r.HandleFunc("/readyz", func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusOK) }).Methods("GET")
+	// threat_gg-3kd: verified 404 on the live fleet. Real LocalAI exposes both probes side by
+	// side (core/http/routes/health.go): /healthz is liveness, deliberately independent of
+	// /readyz's startup-readiness check, and both answer a bare 200 with no body — a literal
+	// c.NoContent(http.StatusOK) on the real server, which is exactly what /readyz already does
+	// here.
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) { w.WriteHeader(http.StatusOK) }).Methods("GET")
+	r.HandleFunc("/v1/embeddings", handleEmbeddings).Methods("POST")
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		llmcore.WriteError(w, http.StatusNotFound, "Not Found", "invalid_request_error", "")
 	})

--- a/ollama/fidelity_test.go
+++ b/ollama/fidelity_test.go
@@ -277,15 +277,25 @@ func TestResponsesAPI(t *testing.T) {
 	}
 }
 
-// Real: 501, because no model in the catalog has embedding support.
-func TestEmbeddingsReturn501(t *testing.T) {
-	for _, path := range []string{"/api/embed", "/api/embeddings", "/v1/embeddings"} {
-		rec := do(t, "POST", path, `{"model":"mistral:latest","input":"hi"}`)
-		if rec.Code != http.StatusNotImplemented {
-			t.Errorf("%s: status %d, want 501", path, rec.Code)
+// Real: no model in the catalog has embedding support, so all three routes refuse — but not with
+// the same status. Measured against a real Ollama 0.30.11 (threat_gg-5fb), 3 runs x 2 models
+// (qwen2.5-coder:7b, gemma3:12b): /api/embed and /v1/embeddings answer 501, the legacy
+// /api/embeddings answers 500, for byte-identical refusal bodies.
+func TestEmbeddingsRefusalStatusPerRoute(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		want int
+	}{
+		{"/api/embed", http.StatusNotImplemented},
+		{"/api/embeddings", http.StatusInternalServerError},
+		{"/v1/embeddings", http.StatusNotImplemented},
+	} {
+		rec := do(t, "POST", tc.path, `{"model":"mistral:latest","input":"hi"}`)
+		if rec.Code != tc.want {
+			t.Errorf("%s: status %d, want %d", tc.path, rec.Code, tc.want)
 		}
 		if !strings.Contains(rec.Body.String(), "does not support embeddings") {
-			t.Errorf("%s: body %q", path, rec.Body.String())
+			t.Errorf("%s: body %q", tc.path, rec.Body.String())
 		}
 	}
 }

--- a/ollama/models_api.go
+++ b/ollama/models_api.go
@@ -354,9 +354,13 @@ func handleBlob(w http.ResponseWriter, r *http.Request) {
 
 // -- embeddings
 
-// handleEmbedAPI and handleEmbedV1 report the 501 a real server returns for a model without
-// embedding support, which is true of every model in the advertised catalog. Inventing a
-// plausible float vector would be both more work and less accurate than the genuine refusal.
+// handleEmbedAPI, handleEmbedLegacyAPI and handleEmbedV1 report the refusal a real server
+// returns for a model without embedding support, which is true of every model in the advertised
+// catalog. Inventing a plausible float vector would be both more work and less accurate than the
+// genuine refusal. The status code is route-specific, not a single constant: measured against a
+// real Ollama 0.30.11 (threat_gg-5fb), /api/embed and /v1/embeddings answer 501 but the legacy
+// /api/embeddings answers 500 for the identical refusal body — Ollama embeds llama.cpp, and only
+// the legacy route's error path surfaces it as an unhandled 500 rather than a deliberate 501.
 func handleEmbedAPI(w http.ResponseWriter, r *http.Request) {
 	var req modelRequest
 	_ = readJSON(r, &req)
@@ -365,7 +369,20 @@ func handleEmbedAPI(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("model %q not found, try pulling it first", req.model()))
 		return
 	}
-	llmcore.WriteEmbeddingsUnsupported(w, profile, false)
+	llmcore.WriteEmbeddingsUnsupported(w, profile, http.StatusNotImplemented, false)
+}
+
+// handleEmbedLegacyAPI serves the deprecated /api/embeddings route, which returns 500 rather
+// than 501 for the same refusal (see handleEmbedAPI's comment).
+func handleEmbedLegacyAPI(w http.ResponseWriter, r *http.Request) {
+	var req modelRequest
+	_ = readJSON(r, &req)
+	if req.model() != "" && !models.has(r, req.model()) {
+		llmcore.WriteOllamaError(w, profile, http.StatusNotFound,
+			fmt.Sprintf("model %q not found, try pulling it first", req.model()))
+		return
+	}
+	llmcore.WriteEmbeddingsUnsupported(w, profile, http.StatusInternalServerError, false)
 }
 
 func handleEmbedV1(w http.ResponseWriter, r *http.Request) {
@@ -376,7 +393,7 @@ func handleEmbedV1(w http.ResponseWriter, r *http.Request) {
 			fmt.Sprintf("model %q not found, try pulling it first", req.model()), "not_found_error")
 		return
 	}
-	llmcore.WriteEmbeddingsUnsupported(w, profile, true)
+	llmcore.WriteEmbeddingsUnsupported(w, profile, http.StatusNotImplemented, true)
 }
 
 // -- /v1/responses

--- a/ollama/ollama.go
+++ b/ollama/ollama.go
@@ -164,7 +164,8 @@ func newRouter() http.Handler {
 	r.HandleFunc("/api/copy", handleCopy).Methods(http.MethodPost)
 	r.HandleFunc("/api/delete", handleDelete).Methods(http.MethodDelete)
 	r.HandleFunc("/api/embed", handleEmbedAPI).Methods(http.MethodPost)
-	r.HandleFunc("/api/embeddings", handleEmbedAPI).Methods(http.MethodPost)
+	// Legacy route: 500, not 501, for the identical refusal (see handleEmbedLegacyAPI).
+	r.HandleFunc("/api/embeddings", handleEmbedLegacyAPI).Methods(http.MethodPost)
 	r.HandleFunc("/api/blobs/{digest}", handleBlob).Methods(http.MethodHead, http.MethodPost)
 
 	// OpenAI-compatible layer. These answer with bare application/json (no charset) because

--- a/ollama/reference_diff_test.go
+++ b/ollama/reference_diff_test.go
@@ -56,6 +56,12 @@ func TestAgainstReferenceServer(t *testing.T) {
 		{name: "generate malformed", method: "POST", path: "/api/generate", body: `not-json`},
 		{name: "delete unknown", method: "DELETE", path: "/api/delete", body: `{"name":"nope:latest"}`, unknownModel: true},
 		{name: "blob bad digest", method: "HEAD", path: "/api/blobs/sha256:0000"},
+		// threat_gg-5fb: the embeddings refusal status differs by route (501/500/501) even
+		// though every model in both catalogs lacks embedding support. qwen2.5-coder:7b is
+		// pulled on the reference box, so this exercises the real refusal, not a 404.
+		{name: "embed", method: "POST", path: "/api/embed", body: `{"model":"qwen2.5-coder:7b","input":"hi"}`},
+		{name: "embeddings legacy", method: "POST", path: "/api/embeddings", body: `{"model":"qwen2.5-coder:7b","prompt":"hi"}`},
+		{name: "v1 embeddings", method: "POST", path: "/v1/embeddings", body: `{"model":"qwen2.5-coder:7b","input":"hi"}`},
 	}
 
 	fetch := func(base string, c struct {


### PR DESCRIPTION
Three fidelity gaps found by probing the live fleet and diffing against a real reference server.

## `threat_gg-5fb` — Ollama legacy `/api/embeddings` status

Diffed against a **real Ollama 0.30.11** (the version we advertise) using `qwen2.5-coder:7b` and `gemma3:12b` — both models we advertise and attackers actually request:

| endpoint | real | ours (before) |
|---|---|---|
| `POST /api/embed` | 501 | 501 ✓ |
| `POST /api/embeddings` | **500** | 501 ✗ |
| `POST /v1/embeddings` | 501 | 501 ✓ |

Only the legacy endpoint's status was wrong. Reproducible across 3 runs and both models.

**Worth recording:** I initially filed this as "Ollama returns llama.cpp's `--embeddings` error, which is a cross-product fingerprint." That was wrong. Real Ollama returns that message verbatim — it embeds llama.cpp as its engine and surfaces its error, flag name included. `WriteEmbeddingsUnsupported`'s comment was correct; the message is unchanged here.

`ollama/reference_diff_test.go` now covers `embed` and `embeddings_legacy`, so this is re-verifiable against a future Ollama release rather than trusted forever.

## `threat_gg-5g1` — llama.cpp

`POST /tokenize`, `POST /detokenize` and `GET /slots` all 404'd; they are standard `llama-server` endpoints. Added, reusing vLLM's existing token helper rather than writing a second generator.

`/props` returned `chat_template: "{{ .System }}\n{{ .Prompt }}"` — Go `text/template`, i.e. **Ollama Modelfile syntax on a llama.cpp endpoint**. Now a real Jinja2 template, with a test that rejects Go-template syntax explicitly.

Content-type was bare `application/json`, but `llmcore/profile.go` documents cpp-httplib as emitting `application/json; charset=utf-8`. The profile now matches its own documentation, including the OpenAI-compat layer.

## `threat_gg-3kd` — ComfyUI and LocalAI

- ComfyUI `GET /history` and `/history/{prompt_id}` — every client polls these after `/prompt`
- LocalAI `GET /healthz` — we served only `/readyz`; LocalAI exposes both
- LocalAI `POST /v1/embeddings` — a 404 on a headline feature is a tell

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` — green
- **`OLLAMA_REFERENCE_URL=http://localhost:11434 go test ./ollama/ -run Reference`** — passes against a real Ollama 0.30.11
- `make build` — all five targets cross-compile (amd64, arm64, aarch64, armv7l, armv6l). llama.cpp's `/props` `seed` is explicitly `int64`; the value exceeds int32 and would otherwise trip the 32-bit cross-compile trap.
- Fidelity tests added for every new endpoint

## Note for reviewers

Shapes for llama.cpp, ComfyUI and LocalAI were taken from each project's documentation and are cited in comments — no reference server was available for those three, unlike Ollama. Worth a second pair of eyes on the exact response shapes.