### PR TITLE
Publish releases only from master — PR builds were auto-deploying to the fleet (threat_gg-0b0)

### DIFF
--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -24,14 +24,41 @@ jobs:
       - name: Build
         run: |
           make build
+      # Publish ONLY from master. The fleet's auto-updater (updater/updater.go) polls
+      # /releases/latest every 15 minutes and installs whatever it finds, so any release
+      # this workflow creates reaches every production honeypot. Before this guard the job
+      # also ran on `pull_request`, which meant unmerged branch code shipped to the fleet:
+      # releases 20260725.30178510632 and .30179101579 were both built from a PR branch and
+      # were running in production, and 20260725.30135742551 came from fix/pseudo-digest.
+      # A PR build is still worth running above (it catches compile and cross-compile
+      # breakage) — it just must not publish.
       - name: Create Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Passed via env, never interpolated into the script body: commit subjects are
+          # attacker-influencable text and ${{ }} interpolation inside run: would splice them
+          # straight into the shell.
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
         run: |
-          gh release create `date -u +%Y%m%d`.${GITHUB_RUN_ID} \
-            --repo="$GIT_REPOSITORY" \
-            --title="Release `date -u +%Y%m%d`.${GITHUB_RUN_ID}" \
-            --notes="`git log --pretty=format:'- %s' $GITHUB_SHA...HEAD`" \
+          set -euo pipefail
+          TAG="$(date -u +%Y%m%d).${GITHUB_RUN_ID}"
+
+          # Range notes when the previous SHA is a real ancestor; fall back to the tip commit
+          # on a first push or a force-push, where the range would be invalid or enormous.
+          if git cat-file -e "${PUSH_BEFORE}^{commit}" 2>/dev/null; then
+            NOTES="$(git log --no-merges --pretty=format:'- %s' "${PUSH_BEFORE}..${PUSH_AFTER}")"
+          else
+            NOTES="$(git log -1 --pretty=format:'- %s' "${PUSH_AFTER}")"
+          fi
+          [ -n "${NOTES}" ] || NOTES="- ${TAG}"
+
+          gh release create "${TAG}" \
+            --repo="${GITHUB_REPOSITORY}" \
+            --title="Release ${TAG}" \
+            --notes="${NOTES}" \
+            --latest \
             ./dist/*
 
 #    steps:


### PR DESCRIPTION
## The bug

`updater/updater.go` polls `/releases/latest` every 15 minutes and installs whatever it finds. The releaser workflow ran on **`pull_request` as well as `push`**, and the release step had no condition — so **every pull request published a release, and the entire production fleet auto-deployed unmerged branch code within 15 minutes.**

This is not theoretical. Auditing the last six releases by triggering event:

| tag | event / branch |
|---|---|
| `20260725.30179157163` | push / master |
| `20260725.30179101579` | **pull_request / fix/llm-fidelity-gaps** |
| `20260725.30178510632` | **pull_request / fix/llm-fidelity-gaps** |
| `20260725.30157989732` | push / master |
| `20260725.30135832464` | push / master |
| `20260725.30135742551` | **pull_request / fix/pseudo-digest** |

Three of six came from PRs. I observed the fleet running **both** PR-built releases simultaneously — some nodes on `.30178510632`, others on `.30179101579`, neither of which existed on master at the time.

`threat_gg-0b0` describes the inverse symptom ("master merged but undeployed") and shares this root cause: master pushes and PR builds race for `latest`, and whichever finished last wins.

## The fix

Gate the release step on `github.event_name == 'push' && github.ref == 'refs/heads/master'`. PR builds still run — they catch compile and cross-compile breakage, which is worth keeping — they just no longer publish.

Three incidental repairs in the same step:

- `--repo="$GIT_REPOSITORY"` — that variable is never set, so it was passing `--repo=""`. Now `${GITHUB_REPOSITORY}`.
- `--notes` used `git log $GITHUB_SHA...HEAD`, which is an empty range on a push, so every release had blank notes. Now the push range, with a fallback for shallow clones and force-pushes.
- Added `--latest` explicitly rather than relying on creation ordering to decide what the fleet installs.

## Security note

Commit subjects are attacker-influencable, so `PUSH_BEFORE`/`PUSH_AFTER` are passed through `env:` and referenced as shell variables. No `${{ }}` interpolation appears inside any `run:` body — verified by parsing the YAML.

## Not done here

The three PR-built releases still exist and are still installable. Deleting published releases is destructive and the fleet has since moved to master's `.30179157163`, so I have left them. Worth a decision separately.

## Test plan

- YAML parses; the gate expression and `env:` keys verified programmatically
- No `${{ }}` in any `run:` body
- Build step unchanged, so PR CI coverage is unaffected
- The real proof is behavioural: this PR should produce a passing build and **no new release**