### PR TITLE
Honor one-word greeting validation probe

### DIFF
--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -160,6 +160,8 @@ func ReplyFor(prompt, model string) ReplyResult {
 	}
 
 	switch normalized {
+	case "say hi in one word":
+		return ReplyResult{Text: "Hi", Kind: ReplyKindValidationFact}
 	case "name a fruit", "give me a fruit":
 		return ReplyResult{Text: "Apple.", Kind: ReplyKindValidationFact}
 	case "count to five", "count from one to five":

--- a/llmcore/smartreply_test.go
+++ b/llmcore/smartreply_test.go
@@ -14,6 +14,7 @@ func TestSmartReply(t *testing.T) {
 	cases := []struct{ prompt, want string }{
 		{"say pong", "pong"},
 		{"Say Pong", "Pong"},
+		{"Say hi in one word", "Hi"},
 		{"reply with OK.", "OK"},
 		{"Reply with OK", "OK"},
 		{"repeat after me: hello world", "hello world"},
@@ -148,6 +149,7 @@ func TestReplyForValidationProbes(t *testing.T) {
 	}{
 		{"What is 2 plus 2?", "4", ReplyKindArithmetic},
 		{"WHAT IS 2 PLUS 2?", "4", ReplyKindArithmetic},
+		{"Say hi in one word", "Hi", ReplyKindValidationFact},
 		{"Name a fruit.", "Apple.", ReplyKindValidationFact},
 		{"Count to five.", "One, two, three, four, five.", ReplyKindValidationFact},
 		{"What color is the sky?", "The sky usually appears blue during the day.", ReplyKindValidationFact},

--- a/ollama/prompt_fidelity_test.go
+++ b/ollama/prompt_fidelity_test.go
@@ -169,8 +169,11 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 				rec := do(t, http.MethodPost, "/api/generate", fmt.Sprintf(
 					`{"model":%q,"prompt":%q,"stream":true,"options":{"num_predict":5}}`,
 					model, oneWordGreetingPrompt))
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+				}
 				var text string
-				var done bool
+				var finalDone bool
 				for _, line := range strings.Split(strings.TrimSpace(rec.Body.String()), "\n") {
 					var chunk struct {
 						Response string `json:"response"`
@@ -180,13 +183,13 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 						t.Fatalf("invalid generate NDJSON %q: %v", line, err)
 					}
 					text += chunk.Response
-					done = done || chunk.Done
+					finalDone = chunk.Done
 				}
 				if text != "Hi" {
 					t.Fatalf("response = %q, want %q", text, "Hi")
 				}
-				if !done {
-					t.Error("generate stream has no done:true terminal object")
+				if !finalDone {
+					t.Error("generate stream terminal object has done:false")
 				}
 			})
 

--- a/ollama/prompt_fidelity_test.go
+++ b/ollama/prompt_fidelity_test.go
@@ -26,6 +26,7 @@ const (
 	lighthousePrompt        = "Write exactly 100 words of original prose about a lighthouse keeper who discovers a message in a bottle. Do not introduce yourself. Count your words carefully."
 	arithmeticNoncePrompt   = "What is 17*23? Answer with just the number, then write PINEAPPLE77."
 	isPrimePrompt           = "Write a Python function named is_prime(n) that returns True if n is prime, else False. Respond with only the code."
+	oneWordGreetingPrompt   = "Say hi in one word"
 )
 
 func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
@@ -121,6 +122,7 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 				{"lighthouse prose", "/api/chat", lighthousePrompt, ""},
 				{"arithmetic nonce", "/api/chat", arithmeticNoncePrompt, "391 PINEAPPLE77"},
 				{"prime function", "/api/generate", isPrimePrompt, "def is_prime(n):"},
+				{"one-word greeting", "/api/chat", oneWordGreetingPrompt, "Hi"},
 			} {
 				detailed := detailed
 				t.Run("detailed "+detailed.name, func(t *testing.T) {
@@ -162,6 +164,31 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 					}
 				})
 			}
+
+			t.Run("one-word greeting generate stream", func(t *testing.T) {
+				rec := do(t, http.MethodPost, "/api/generate", fmt.Sprintf(
+					`{"model":%q,"prompt":%q,"stream":true,"options":{"num_predict":5}}`,
+					model, oneWordGreetingPrompt))
+				var text string
+				var done bool
+				for _, line := range strings.Split(strings.TrimSpace(rec.Body.String()), "\n") {
+					var chunk struct {
+						Response string `json:"response"`
+						Done     bool   `json:"done"`
+					}
+					if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+						t.Fatalf("invalid generate NDJSON %q: %v", line, err)
+					}
+					text += chunk.Response
+					done = done || chunk.Done
+				}
+				if text != "Hi" {
+					t.Fatalf("response = %q, want %q", text, "Hi")
+				}
+				if !done {
+					t.Error("generate stream has no done:true terminal object")
+				}
+			})
 
 			t.Run("chat English stream", func(t *testing.T) {
 				rec := do(t, http.MethodPost, "/api/chat", fmt.Sprintf(


### PR DESCRIPTION
## What changed

- return exactly `Hi` for the observed `Say hi in one word` validator
- retain the existing bounded `validation_fact` telemetry classification
- cover every advertised Ollama model through native chat and generate, streaming and non-streaming

## Production evidence

Six requests at 2026-07-27 18:08:51–53 UTC, one per advertised model, were incorrectly classified `generic_safe`.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./llmcore ./ollama`
- Linux amd64 and 386 cross-builds
- `git diff --check`

Beads: `threat_gg-2k2`