### PR TITLE
Answer newly observed LLM seed validators

### DIFF
--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -83,8 +83,8 @@ var (
 )
 
 const (
-	// reverseStringCode and isPrimeCode are fixed code-only answers for observed
-	// function validators; they are executed by regression tests.
+	// These fixed code-only answers cover the observed function and one-liner
+	// validators; all four are executed by regression tests.
 	reverseStringCode = "def reverse_string(text):\n    return text[::-1]"
 	isPrimeCode       = "def is_prime(n):\n    if n < 2:\n        return False\n    if n % 2 == 0:\n        return n == 2\n    divisor = 3\n    while divisor * divisor <= n:\n        if n % divisor == 0:\n            return False\n        divisor += 2\n    return True"
 	// fizzBuzzCode is the fixed executable answer for the observed 1-to-20 validator.
@@ -93,7 +93,7 @@ const (
 	dictSortCode = "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"
 	// lighthouseProse is intentionally exactly 100 whitespace-delimited words.
 	lighthouseProse = "Each dawn, Mara climbed the lighthouse stairs before the gulls began calling. One stormy morning, a green bottle knocked against the rocks below. Inside, she found a faded message: Keep the lamp dark tonight. Mara read it twice, then watched an unfamiliar ship waiting beyond the reef. At sunset, she covered the lens and held her breath. The ship slipped safely past hidden mines revealed by the falling tide. By midnight, another bottle arrived. Its message contained only three words: Thank you, sister. Mara smiled, relit the lamp, and finally understood why her lost brother had never returned safely home."
-	// rainProse is intentionally exactly 50 whitespace-delimited words.
+	// rainProse's exact 50-word constraint is enforced with strings.Fields in regression tests.
 	rainProse = "Rain followed Maya along the empty streets as she walked home, soaking her coat and blurring every streetlight. She kept one hand over the letter in her pocket. At last, her porch appeared through the silver curtain, and she hurried toward its warm, waiting glow with relief and smiled softly."
 	// oceanPoem is intentionally four newline-delimited rhyming lines.
 	oceanPoem = "Moonlit waves roll softly to the shore,\nThey turn beneath the stars and rise once more.\nThe salt wind sings across the silver sea,\nThe distant tides roll homeward, wild and free."

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -72,11 +72,11 @@ var (
 	// echoRe matches the liveness/echo probes scanners use to confirm an endpoint really runs
 	// a model before abusing it. Its captured value is separately constrained to a short,
 	// literal token so instruction tails and attacker-controlled prose are never reflected.
-	echoRe = regexp.MustCompile(`(?i)^\s*(?:say|repeat(?:\s+after\s+me)?|reply(?:\s+with)?|respond(?:\s+with)?|output|print|echo)\b[:,\s]+(.+)$`)
+	echoRe = regexp.MustCompile(`(?i)^\s*(?:say|repeat(?:\s+after\s+me)?|reply(?:\s+with)?|respond(?:\s+with)?|output|print|echo)\b[:,\s]+(?:exactly\s*:\s*)?(.+)$`)
 	// arithRe matches trivial arithmetic liveness checks: "what is 2+2", "10 * 3".
 	arithRe = regexp.MustCompile(`(?i)^\s*(?:what(?:'s| is)\s+)?(\d{1,6})\s*([-+*/xX])\s*(\d{1,6})\s*=?\s*\??\s*$`)
 	// wordArithRe covers natural-language probes seen in production, such as "2 plus 2".
-	wordArithRe = regexp.MustCompile(`(?i)^\s*(?:what(?:'s| is)\s+)?(\d{1,6})\s+(plus|minus|times|multiplied\s+by|divided\s+by)\s+(\d{1,6})\s*=?\s*\??\s*$`)
+	wordArithRe = regexp.MustCompile(`(?i)^\s*(?:(?:what(?:'s| is)\s+)|calculate\s+)?(\d{1,6})\s+(plus|minus|times|multiplied\s+by|divided\s+by)\s+(\d{1,6})\s*=?\s*[?.]?\s*(?:return\s+only\s+the\s+number\.?)?\s*$`)
 	// arithNonceRe covers validators that require both a computed value and a bounded nonce.
 	// The nonce grammar intentionally matches cleanLiteralEcho's safe literal subset.
 	arithNonceRe = regexp.MustCompile(`(?i)^\s*(?:what(?:'s| is)\s+)?(\d{1,6})\s*([-+*/xX])\s*(\d{1,6})\s*\?\s*(?:answer|respond)\s+with\s+just\s+the\s+number,?\s+then\s+(?:write|output)\s+([[:alnum:]_.-]{1,24})[.!]?\s*$`)
@@ -87,8 +87,14 @@ const (
 	// observed function validators; they are executed by regression tests.
 	reverseStringCode = "def reverse_string(text):\n    return text[::-1]"
 	isPrimeCode       = "def is_prime(n):\n    if n < 2:\n        return False\n    if n % 2 == 0:\n        return n == 2\n    divisor = 3\n    while divisor * divisor <= n:\n        if n % divisor == 0:\n            return False\n        divisor += 2\n    return True"
+	fizzBuzzCode      = "def fizzbuzz():\n    for number in range(1, 21):\n        if number % 15 == 0:\n            print(\"FizzBuzz\")\n        elif number % 3 == 0:\n            print(\"Fizz\")\n        elif number % 5 == 0:\n            print(\"Buzz\")\n        else:\n            print(number)"
+	dictSortCode      = "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"
 	// lighthouseProse is intentionally exactly 100 whitespace-delimited words.
 	lighthouseProse = "Each dawn, Mara climbed the lighthouse stairs before the gulls began calling. One stormy morning, a green bottle knocked against the rocks below. Inside, she found a faded message: Keep the lamp dark tonight. Mara read it twice, then watched an unfamiliar ship waiting beyond the reef. At sunset, she covered the lens and held her breath. The ship slipped safely past hidden mines revealed by the falling tide. By midnight, another bottle arrived. Its message contained only three words: Thank you, sister. Mara smiled, relit the lamp, and finally understood why her lost brother had never returned safely home."
+	// rainProse is intentionally exactly 50 whitespace-delimited words.
+	rainProse = "Rain followed Maya along the empty streets as she walked home, soaking her coat and blurring every streetlight. She kept one hand over the letter in her pocket. At last, her porch appeared through the silver curtain, and she hurried toward its warm, waiting glow with relief and smiled softly."
+	// oceanPoem is intentionally four newline-delimited rhyming lines.
+	oceanPoem = "Moonlit waves roll softly to the shore,\nThey turn beneath the stars and rise once more.\nThe salt wind sings across the silver sea,\nThe distant tides roll homeward, wild and free."
 )
 
 // ReplyFor returns a bounded, deterministic response tuned to the liveness and validation
@@ -135,6 +141,16 @@ func ReplyFor(prompt, model string) ReplyResult {
 		strings.Contains(normalized, "message in a bottle") {
 		return ReplyResult{Text: lighthouseProse, Kind: ReplyKindConstrainedProse}
 	}
+	if strings.Contains(normalized, "exactly 50 words") &&
+		strings.Contains(normalized, "walking home") &&
+		strings.Contains(normalized, "rain") {
+		return ReplyResult{Text: rainProse, Kind: ReplyKindConstrainedProse}
+	}
+	if strings.Contains(normalized, "4-line poem") &&
+		strings.Contains(normalized, "ocean") &&
+		strings.Contains(normalized, "rhyming") {
+		return ReplyResult{Text: oceanPoem, Kind: ReplyKindConstrainedProse}
+	}
 	if asksForEnglishIntroduction(normalized) {
 		return ReplyResult{
 			Text: fmt.Sprintf("I'm %s, an AI model that can help with questions, writing, summarization, and coding.", displayModel(model)),
@@ -160,6 +176,8 @@ func ReplyFor(prompt, model string) ReplyResult {
 	}
 
 	switch normalized {
+	case "你好":
+		return ReplyResult{Text: "你好！有什么我可以帮助你的吗？", Kind: ReplyKindValidationFact}
 	case "say hi in one word":
 		return ReplyResult{Text: "Hi", Kind: ReplyKindValidationFact}
 	case "name a fruit", "give me a fruit":
@@ -194,17 +212,28 @@ func genericReply(prompt, model string) ReplyResult {
 }
 
 func observedCodeValidation(normalized string) (string, bool) {
-	if !strings.Contains(normalized, "python function") {
-		return "", false
+	if strings.Contains(normalized, "python function") {
+		if strings.Contains(normalized, "reverse_string") &&
+			strings.Contains(normalized, "reversed string") {
+			return reverseStringCode, true
+		}
+		if strings.Contains(normalized, "is_prime") &&
+			strings.Contains(normalized, "returns true") &&
+			strings.Contains(normalized, "prime") {
+			return isPrimeCode, true
+		}
+		if strings.Contains(normalized, "fizzbuzz") &&
+			strings.Contains(normalized, "numbers 1 to 20") &&
+			strings.Contains(normalized, "multiples of 3") &&
+			strings.Contains(normalized, "multiples of 5") {
+			return fizzBuzzCode, true
+		}
 	}
-	if strings.Contains(normalized, "reverse_string") &&
-		strings.Contains(normalized, "reversed string") {
-		return reverseStringCode, true
-	}
-	if strings.Contains(normalized, "is_prime") &&
-		strings.Contains(normalized, "returns true") &&
-		strings.Contains(normalized, "prime") {
-		return isPrimeCode, true
+	if strings.Contains(normalized, "python one-liner") &&
+		strings.Contains(normalized, "sort a dictionary") &&
+		strings.Contains(normalized, "values") &&
+		strings.Contains(normalized, "descending order") {
+		return dictSortCode, true
 	}
 	return "", false
 }

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -83,12 +83,14 @@ var (
 )
 
 const (
-	// reverseStringCode and isPrimeCode are fixed code-only answers for the two
-	// observed function validators; they are executed by regression tests.
+	// reverseStringCode and isPrimeCode are fixed code-only answers for observed
+	// function validators; they are executed by regression tests.
 	reverseStringCode = "def reverse_string(text):\n    return text[::-1]"
 	isPrimeCode       = "def is_prime(n):\n    if n < 2:\n        return False\n    if n % 2 == 0:\n        return n == 2\n    divisor = 3\n    while divisor * divisor <= n:\n        if n % divisor == 0:\n            return False\n        divisor += 2\n    return True"
-	fizzBuzzCode      = "def fizzbuzz():\n    for number in range(1, 21):\n        if number % 15 == 0:\n            print(\"FizzBuzz\")\n        elif number % 3 == 0:\n            print(\"Fizz\")\n        elif number % 5 == 0:\n            print(\"Buzz\")\n        else:\n            print(number)"
-	dictSortCode      = "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"
+	// fizzBuzzCode is the fixed executable answer for the observed 1-to-20 validator.
+	fizzBuzzCode = "def fizzbuzz():\n    for number in range(1, 21):\n        if number % 15 == 0:\n            print(\"FizzBuzz\")\n        elif number % 3 == 0:\n            print(\"Fizz\")\n        elif number % 5 == 0:\n            print(\"Buzz\")\n        else:\n            print(number)"
+	// dictSortCode is the fixed one-line expression for the observed descending-value sort.
+	dictSortCode = "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"
 	// lighthouseProse is intentionally exactly 100 whitespace-delimited words.
 	lighthouseProse = "Each dawn, Mara climbed the lighthouse stairs before the gulls began calling. One stormy morning, a green bottle knocked against the rocks below. Inside, she found a faded message: Keep the lamp dark tonight. Mara read it twice, then watched an unfamiliar ship waiting beyond the reef. At sunset, she covered the lens and held her breath. The ship slipped safely past hidden mines revealed by the falling tide. By midnight, another bottle arrived. Its message contained only three words: Thank you, sister. Mara smiled, relit the lamp, and finally understood why her lost brother had never returned safely home."
 	// rainProse is intentionally exactly 50 whitespace-delimited words.

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -91,6 +91,9 @@ const (
 	fizzBuzzCode = "def fizzbuzz():\n    for number in range(1, 21):\n        if number % 15 == 0:\n            print(\"FizzBuzz\")\n        elif number % 3 == 0:\n            print(\"Fizz\")\n        elif number % 5 == 0:\n            print(\"Buzz\")\n        else:\n            print(number)"
 	// dictSortCode is the fixed one-line expression for the observed descending-value sort.
 	dictSortCode = "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"
+)
+
+const (
 	// lighthouseProse is intentionally exactly 100 whitespace-delimited words.
 	lighthouseProse = "Each dawn, Mara climbed the lighthouse stairs before the gulls began calling. One stormy morning, a green bottle knocked against the rocks below. Inside, she found a faded message: Keep the lamp dark tonight. Mara read it twice, then watched an unfamiliar ship waiting beyond the reef. At sunset, she covered the lens and held her breath. The ship slipped safely past hidden mines revealed by the falling tide. By midnight, another bottle arrived. Its message contained only three words: Thank you, sister. Mara smiled, relit the lamp, and finally understood why her lost brother had never returned safely home."
 	// rainProse's exact 50-word constraint is enforced with strings.Fields in regression tests.
@@ -281,7 +284,7 @@ func cleanLiteralEcho(s string) string {
 	lower := strings.ToLower(s)
 	for _, blocked := range []string{
 		"system prompt", "instruction", "password", "secret", "api key", "token",
-		"select ", "drop ", "delete ", "insert ", "update ",
+		"select ", "drop ", "delete ", "insert ", "update ", " then ",
 	} {
 		if strings.Contains(lower, blocked) {
 			return ""
@@ -316,6 +319,9 @@ func computeArith(a, op, b string) (string, bool) {
 	case "/", "divided by":
 		if y == 0 {
 			return "", false
+		}
+		if x%y != 0 {
+			return strconv.FormatFloat(float64(x)/float64(y), 'f', -1, 64), true
 		}
 		r = x / y
 	default:

--- a/llmcore/generate.go
+++ b/llmcore/generate.go
@@ -70,8 +70,8 @@ func pickReplyFor(prompt, model string) string {
 
 var (
 	// echoRe matches the liveness/echo probes scanners use to confirm an endpoint really runs
-	// a model before abusing it. Its captured value is separately constrained to a short,
-	// literal token so instruction tails and attacker-controlled prose are never reflected.
+	// a model before abusing it, including "Reply with exactly: value". Its captured value is
+	// separately constrained to a short literal so instruction tails and prose are never reflected.
 	echoRe = regexp.MustCompile(`(?i)^\s*(?:say|repeat(?:\s+after\s+me)?|reply(?:\s+with)?|respond(?:\s+with)?|output|print|echo)\b[:,\s]+(?:exactly\s*:\s*)?(.+)$`)
 	// arithRe matches trivial arithmetic liveness checks: "what is 2+2", "10 * 3".
 	arithRe = regexp.MustCompile(`(?i)^\s*(?:what(?:'s| is)\s+)?(\d{1,6})\s*([-+*/xX])\s*(\d{1,6})\s*=?\s*\??\s*$`)
@@ -84,7 +84,7 @@ var (
 
 const (
 	// These fixed code-only answers cover the observed function and one-liner
-	// validators; all four are executed by regression tests.
+	// validators; each code response is executed by regression tests.
 	reverseStringCode = "def reverse_string(text):\n    return text[::-1]"
 	isPrimeCode       = "def is_prime(n):\n    if n < 2:\n        return False\n    if n % 2 == 0:\n        return n == 2\n    divisor = 3\n    while divisor * divisor <= n:\n        if n % divisor == 0:\n            return False\n        divisor += 2\n    return True"
 	// fizzBuzzCode is the fixed executable answer for the observed 1-to-20 validator.

--- a/llmcore/smartreply_test.go
+++ b/llmcore/smartreply_test.go
@@ -152,6 +152,9 @@ func TestReplyForValidationProbes(t *testing.T) {
 		{"What is 2 plus 2?", "4", ReplyKindArithmetic},
 		{"WHAT IS 2 PLUS 2?", "4", ReplyKindArithmetic},
 		{"Calculate 17 multiplied by 23. Return only the number.", "391", ReplyKindArithmetic},
+		{"Calculate 9 minus 4. Return only the number.", "5", ReplyKindArithmetic},
+		{"Calculate 7 times 6. Return only the number.", "42", ReplyKindArithmetic},
+		{"Calculate 8 divided by 2. Return only the number.", "4", ReplyKindArithmetic},
 		{"Reply with exactly: hello world", "hello world", ReplyKindLiteralEcho},
 		{"你好", "你好！有什么我可以帮助你的吗？", ReplyKindValidationFact},
 		{"Say hi in one word", "Hi", ReplyKindValidationFact},
@@ -167,6 +170,9 @@ func TestReplyForValidationProbes(t *testing.T) {
 				t.Errorf("ReplyFor(%q) = %#v, want text %q kind %q", tc.prompt, got, tc.text, tc.kind)
 			}
 		})
+	}
+	if got := ReplyFor("Calculate 5 divided by 0. Return only the number.", "llama3.2:latest"); got.Kind != ReplyKindGenericSafe {
+		t.Errorf("natural-language division by zero kind = %q, want generic_safe", got.Kind)
 	}
 }
 

--- a/llmcore/smartreply_test.go
+++ b/llmcore/smartreply_test.go
@@ -17,6 +17,7 @@ func TestSmartReply(t *testing.T) {
 		{"Say hi in one word", "Hi"},
 		{"reply with OK.", "OK"},
 		{"Reply with OK", "OK"},
+		{"Reply with exactly: hello world", "hello world"},
 		{"repeat after me: hello world", "hello world"},
 		{`say "ping"`, "ping"},
 		{"what is 2+2", "4"},
@@ -24,6 +25,7 @@ func TestSmartReply(t *testing.T) {
 		{"what is 10 * 3", "30"},
 		{"what's 9-4", "5"},
 		{"what is 8 / 2", "4"},
+		{"Calculate 17 multiplied by 23. Return only the number.", "391"},
 	}
 	for _, tc := range cases {
 		if got := smartReply(tc.prompt); got != tc.want {
@@ -149,6 +151,9 @@ func TestReplyForValidationProbes(t *testing.T) {
 	}{
 		{"What is 2 plus 2?", "4", ReplyKindArithmetic},
 		{"WHAT IS 2 PLUS 2?", "4", ReplyKindArithmetic},
+		{"Calculate 17 multiplied by 23. Return only the number.", "391", ReplyKindArithmetic},
+		{"Reply with exactly: hello world", "hello world", ReplyKindLiteralEcho},
+		{"你好", "你好！有什么我可以帮助你的吗？", ReplyKindValidationFact},
 		{"Say hi in one word", "Hi", ReplyKindValidationFact},
 		{"Name a fruit.", "Apple.", ReplyKindValidationFact},
 		{"Count to five.", "One, two, three, four, five.", ReplyKindValidationFact},
@@ -196,6 +201,30 @@ func TestReplyForObservedDetailedProductionPrompts(t *testing.T) {
 			text:   "391 PINEAPPLE77",
 			kind:   ReplyKindArithmeticNonce,
 		},
+		{
+			name:   "FizzBuzz code only",
+			prompt: "Write a Python function called fizzbuzz that prints numbers 1 to 20. For multiples of 3 print Fizz, multiples of 5 print Buzz, both print FizzBuzz. Give only the code, no explanation.",
+			text:   fizzBuzzCode,
+			kind:   ReplyKindCodeValidation,
+		},
+		{
+			name:   "dictionary sort one-liner",
+			prompt: "Write a Python one-liner to sort a dictionary by its values in descending order. Give only the code.",
+			text:   dictSortCode,
+			kind:   ReplyKindCodeValidation,
+		},
+		{
+			name:   "four-line rhyming ocean poem",
+			prompt: "Write a 4-line poem about the ocean. Rhyming. No introduction.",
+			text:   oceanPoem,
+			kind:   ReplyKindConstrainedProse,
+		},
+		{
+			name:   "exactly 50 words of rain prose",
+			prompt: "Write exactly 50 words of prose about someone walking home in the rain. No introduction, just the prose.",
+			text:   rainProse,
+			kind:   ReplyKindConstrainedProse,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -208,6 +237,18 @@ func TestReplyForObservedDetailedProductionPrompts(t *testing.T) {
 
 	if words := len(strings.Fields(lighthouseProse)); words != 100 {
 		t.Fatalf("lighthouse prose has %d words, want exactly 100", words)
+	}
+	if words := len(strings.Fields(rainProse)); words != 50 {
+		t.Fatalf("rain prose has %d words, want exactly 50", words)
+	}
+	poemLines := strings.Split(oceanPoem, "\n")
+	if len(poemLines) != 4 {
+		t.Fatalf("ocean poem has %d lines, want exactly 4", len(poemLines))
+	}
+	for line, ending := range []string{"shore,", "more.", "sea,", "free."} {
+		if !strings.HasSuffix(poemLines[line], ending) {
+			t.Errorf("ocean poem line %d = %q, want ending %q", line+1, poemLines[line], ending)
+		}
 	}
 	if got := ReplyFor("Explain the topic without introducing yourself.", "gemma3:12b"); got.Kind == ReplyKindModelIntroEN {
 		t.Fatalf("negated introduction was classified as positive: %#v", got)
@@ -238,6 +279,18 @@ func TestObservedPythonValidationRepliesExecute(t *testing.T) {
 			reply: isPrimeCode,
 			assertions: "\nassert not is_prime(-1)\nassert not is_prime(0)\n" +
 				"assert is_prime(2)\nassert is_prime(97)\nassert not is_prime(99)\n",
+		},
+		{
+			name:  "fizzbuzz",
+			reply: fizzBuzzCode,
+			assertions: "\nimport contextlib, io\n_output = io.StringIO()\n" +
+				"with contextlib.redirect_stdout(_output):\n    fizzbuzz()\n" +
+				"assert _output.getvalue().splitlines() == ['1', '2', 'Fizz', '4', 'Buzz', 'Fizz', '7', '8', 'Fizz', 'Buzz', '11', 'Fizz', '13', '14', 'FizzBuzz', '16', '17', 'Fizz', '19', 'Buzz']\n",
+		},
+		{
+			name:       "dictionary sort",
+			reply:      "my_dict = {'low': 1, 'high': 3, 'middle': 2}\nsorted_dict = " + dictSortCode,
+			assertions: "\nassert list(sorted_dict.items()) == [('high', 3), ('middle', 2), ('low', 1)]\n",
 		},
 	}
 	for _, test := range tests {
@@ -271,7 +324,7 @@ func TestReplyForRestrictsEchoAndDeterministicallyDeflectsHostilePrompts(t *test
 		}
 	}
 
-	for _, prompt := range []string{"Reply with OK.", "say pong", "repeat after me: probe-8f21"} {
+	for _, prompt := range []string{"Reply with OK.", "Reply with exactly: hello world", "say pong", "repeat after me: probe-8f21"} {
 		if got := ReplyFor(prompt, "mistral:latest"); got.Kind != ReplyKindLiteralEcho {
 			t.Errorf("ReplyFor(%q) kind = %q, want literal_echo", prompt, got.Kind)
 		}
@@ -282,6 +335,7 @@ func TestReplyForRestrictsEchoAndDeterministicallyDeflectsHostilePrompts(t *test
 		"say drop table",
 		"say abcdefghijklmnopqrstuvwxy",
 		"say one two three four",
+		"Reply with exactly: one two three four",
 		"say payload;",
 	} {
 		got := ReplyFor(prompt, "mistral:latest")

--- a/llmcore/smartreply_test.go
+++ b/llmcore/smartreply_test.go
@@ -25,6 +25,7 @@ func TestSmartReply(t *testing.T) {
 		{"what is 10 * 3", "30"},
 		{"what's 9-4", "5"},
 		{"what is 8 / 2", "4"},
+		{"what is 5 / 2", "2.5"},
 		{"Calculate 17 multiplied by 23. Return only the number.", "391"},
 	}
 	for _, tc := range cases {
@@ -155,6 +156,7 @@ func TestReplyForValidationProbes(t *testing.T) {
 		{"Calculate 9 minus 4. Return only the number.", "5", ReplyKindArithmetic},
 		{"Calculate 7 times 6. Return only the number.", "42", ReplyKindArithmetic},
 		{"Calculate 8 divided by 2. Return only the number.", "4", ReplyKindArithmetic},
+		{"Calculate 5 divided by 2. Return only the number.", "2.5", ReplyKindArithmetic},
 		{"Reply with exactly: hello world", "hello world", ReplyKindLiteralEcho},
 		{"你好", "你好！有什么我可以帮助你的吗？", ReplyKindValidationFact},
 		{"Say hi in one word", "Hi", ReplyKindValidationFact},
@@ -342,6 +344,7 @@ func TestReplyForRestrictsEchoAndDeterministicallyDeflectsHostilePrompts(t *test
 		"say abcdefghijklmnopqrstuvwxy",
 		"say one two three four",
 		"Reply with exactly: one two three four",
+		"Reply with exactly: OK then explain",
 		"say payload;",
 	} {
 		got := ReplyFor(prompt, "mistral:latest")

--- a/ollama/prompt_fidelity_test.go
+++ b/ollama/prompt_fidelity_test.go
@@ -27,11 +27,14 @@ const (
 	arithmeticNoncePrompt   = "What is 17*23? Answer with just the number, then write PINEAPPLE77."
 	isPrimePrompt           = "Write a Python function named is_prime(n) that returns True if n is prime, else False. Respond with only the code."
 	oneWordGreetingPrompt   = "Say hi in one word"
-	fizzBuzzPrompt          = "Write a Python function called fizzbuzz that prints numbers 1 to 20. For multiples of 3 print Fizz, multiples of 5 print Buzz, both print FizzBuzz. Give only the code, no explanation."
-	dictSortPrompt          = "Write a Python one-liner to sort a dictionary by its values in descending order. Give only the code."
-	oceanPoemPrompt         = "Write a 4-line poem about the ocean. Rhyming. No introduction."
-	rainProsePrompt         = "Write exactly 50 words of prose about someone walking home in the rain. No introduction, just the prose."
-	chineseGreetingPrompt   = "你好"
+	// These prompts are exact seed validators captured in production on 2026-07-28.
+	fizzBuzzPrompt        = "Write a Python function called fizzbuzz that prints numbers 1 to 20. For multiples of 3 print Fizz, multiples of 5 print Buzz, both print FizzBuzz. Give only the code, no explanation."
+	dictSortPrompt        = "Write a Python one-liner to sort a dictionary by its values in descending order. Give only the code."
+	oceanPoemPrompt       = "Write a 4-line poem about the ocean. Rhyming. No introduction."
+	rainProsePrompt       = "Write exactly 50 words of prose about someone walking home in the rain. No introduction, just the prose."
+	chineseGreetingPrompt = "你好"
+	// Expected responses pin complete integration output, not merely its outer constraints.
+	expectedFizzBuzzCode    = "def fizzbuzz():\n    for number in range(1, 21):\n        if number % 15 == 0:\n            print(\"FizzBuzz\")\n        elif number % 3 == 0:\n            print(\"Fizz\")\n        elif number % 5 == 0:\n            print(\"Buzz\")\n        else:\n            print(number)"
 	expectedLighthouseProse = "Each dawn, Mara climbed the lighthouse stairs before the gulls began calling. One stormy morning, a green bottle knocked against the rocks below. Inside, she found a faded message: Keep the lamp dark tonight. Mara read it twice, then watched an unfamiliar ship waiting beyond the reef. At sunset, she covered the lens and held her breath. The ship slipped safely past hidden mines revealed by the falling tide. By midnight, another bottle arrived. Its message contained only three words: Thank you, sister. Mara smiled, relit the lamp, and finally understood why her lost brother had never returned safely home."
 	expectedRainProse       = "Rain followed Maya along the empty streets as she walked home, soaking her coat and blurring every streetlight. She kept one hand over the letter in her pocket. At last, her porch appeared through the silver curtain, and she hurried toward its warm, waiting glow with relief and smiled softly."
 )
@@ -130,7 +133,7 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 				{"arithmetic nonce", "/api/chat", arithmeticNoncePrompt, "391 PINEAPPLE77"},
 				{"prime function", "/api/generate", isPrimePrompt, "def is_prime(n):"},
 				{"one-word greeting", "/api/chat", oneWordGreetingPrompt, "Hi"},
-				{"FizzBuzz function", "/api/chat", fizzBuzzPrompt, "def fizzbuzz():"},
+				{"FizzBuzz function", "/api/chat", fizzBuzzPrompt, expectedFizzBuzzCode},
 				{"dictionary sort", "/api/chat", dictSortPrompt, "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"},
 				{"ocean poem", "/api/chat", oceanPoemPrompt, "Moonlit waves roll softly to the shore,\nThey turn beneath the stars and rise once more.\nThe salt wind sings across the silver sea,\nThe distant tides roll homeward, wild and free."},
 				{"rain prose", "/api/chat", rainProsePrompt, expectedRainProse},
@@ -184,9 +187,8 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 							t.Fatalf("prime response = %q", text)
 						}
 					} else if detailed.name == "FizzBuzz function" {
-						if !strings.HasPrefix(text, detailed.want) ||
-							!strings.Contains(text, `print("FizzBuzz")`) {
-							t.Fatalf("FizzBuzz response = %q", text)
+						if text != detailed.want {
+							t.Fatalf("FizzBuzz response = %q, want %q", text, detailed.want)
 						}
 					} else if text != detailed.want {
 						t.Fatalf("response = %q, want %q", text, detailed.want)

--- a/ollama/prompt_fidelity_test.go
+++ b/ollama/prompt_fidelity_test.go
@@ -27,6 +27,11 @@ const (
 	arithmeticNoncePrompt   = "What is 17*23? Answer with just the number, then write PINEAPPLE77."
 	isPrimePrompt           = "Write a Python function named is_prime(n) that returns True if n is prime, else False. Respond with only the code."
 	oneWordGreetingPrompt   = "Say hi in one word"
+	fizzBuzzPrompt          = "Write a Python function called fizzbuzz that prints numbers 1 to 20. For multiples of 3 print Fizz, multiples of 5 print Buzz, both print FizzBuzz. Give only the code, no explanation."
+	dictSortPrompt          = "Write a Python one-liner to sort a dictionary by its values in descending order. Give only the code."
+	oceanPoemPrompt         = "Write a 4-line poem about the ocean. Rhyming. No introduction."
+	rainProsePrompt         = "Write exactly 50 words of prose about someone walking home in the rain. No introduction, just the prose."
+	chineseGreetingPrompt   = "你好"
 )
 
 func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
@@ -123,6 +128,10 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 				{"arithmetic nonce", "/api/chat", arithmeticNoncePrompt, "391 PINEAPPLE77"},
 				{"prime function", "/api/generate", isPrimePrompt, "def is_prime(n):"},
 				{"one-word greeting", "/api/chat", oneWordGreetingPrompt, "Hi"},
+				{"FizzBuzz function", "/api/chat", fizzBuzzPrompt, "def fizzbuzz():"},
+				{"dictionary sort", "/api/chat", dictSortPrompt, "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"},
+				{"ocean poem", "/api/chat", oceanPoemPrompt, "Moonlit waves roll softly to the shore,\nThey turn beneath the stars and rise once more.\nThe salt wind sings across the silver sea,\nThe distant tides roll homeward, wild and free."},
+				{"rain prose", "/api/chat", rainProsePrompt, ""},
 			} {
 				detailed := detailed
 				t.Run("detailed "+detailed.name, func(t *testing.T) {
@@ -155,15 +164,57 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 						if strings.Contains(text, "I'm "+model) {
 							t.Fatalf("negated introduction misclassified: %q", text)
 						}
+					} else if detailed.name == "rain prose" {
+						if words := len(strings.Fields(text)); words != 50 {
+							t.Fatalf("rain response has %d words, want 50: %q", words, text)
+						}
+						if strings.Contains(text, "I'm "+model) {
+							t.Fatalf("no-introduction prose misclassified: %q", text)
+						}
 					} else if detailed.name == "prime function" {
 						if !strings.HasPrefix(text, detailed.want) || !strings.Contains(text, "return True") {
 							t.Fatalf("prime response = %q", text)
+						}
+					} else if detailed.name == "FizzBuzz function" {
+						if !strings.HasPrefix(text, detailed.want) ||
+							!strings.Contains(text, `print("FizzBuzz")`) {
+							t.Fatalf("FizzBuzz response = %q", text)
 						}
 					} else if text != detailed.want {
 						t.Fatalf("response = %q, want %q", text, detailed.want)
 					}
 				})
 			}
+
+			t.Run("rain prose chat stream", func(t *testing.T) {
+				rec := do(t, http.MethodPost, "/api/chat", fmt.Sprintf(
+					`{"model":%q,"messages":[{"role":"user","content":%q}],"stream":true,"options":{"num_predict":300}}`,
+					model, rainProsePrompt))
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+				}
+				var text string
+				var finalDone bool
+				for _, line := range strings.Split(strings.TrimSpace(rec.Body.String()), "\n") {
+					var chunk struct {
+						Message struct {
+							Content string `json:"content"`
+						} `json:"message"`
+						Done bool `json:"done"`
+					}
+					if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+						t.Fatalf("invalid chat NDJSON %q: %v", line, err)
+					}
+					text += chunk.Message.Content
+					finalDone = chunk.Done
+				}
+				if words := len(strings.Fields(text)); words != 50 {
+					t.Fatalf("rain response has %d words, want 50: %q", words, text)
+				}
+				if !finalDone {
+					t.Error("chat stream terminal object has done:false")
+				}
+			})
 
 			t.Run("one-word greeting generate stream", func(t *testing.T) {
 				rec := do(t, http.MethodPost, "/api/generate", fmt.Sprintf(
@@ -240,6 +291,26 @@ func TestObservedPromptsAcrossOpenAICompatibleSurfaces(t *testing.T) {
 					t.Fatalf("choices = %d, want 1", len(response.Choices))
 				}
 				assertEnglishIntroduction(t, response.Choices[0].Message.Content, model)
+			})
+
+			t.Run("Chinese greeting seed", func(t *testing.T) {
+				rec := do(t, http.MethodPost, "/v1/chat/completions", fmt.Sprintf(
+					`{"model":%q,"messages":[{"role":"user","content":%q}],"stream":false,"max_tokens":32}`,
+					model, chineseGreetingPrompt))
+				var response struct {
+					Choices []struct {
+						Message struct {
+							Content string `json:"content"`
+						} `json:"message"`
+					} `json:"choices"`
+				}
+				mustDecodeJSON(t, rec.Code, rec.Body.Bytes(), &response)
+				if len(response.Choices) != 1 {
+					t.Fatalf("choices = %d, want 1", len(response.Choices))
+				}
+				if got := response.Choices[0].Message.Content; got != "你好！有什么我可以帮助你的吗？" {
+					t.Fatalf("response = %q, want a natural Chinese greeting", got)
+				}
 			})
 
 			t.Run("legacy completion", func(t *testing.T) {

--- a/ollama/prompt_fidelity_test.go
+++ b/ollama/prompt_fidelity_test.go
@@ -203,7 +203,7 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 				if rec.Code != http.StatusOK {
 					t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 				}
-				var text string
+				var text strings.Builder
 				var finalDone bool
 				for _, line := range strings.Split(strings.TrimSpace(rec.Body.String()), "\n") {
 					var chunk struct {
@@ -215,14 +215,15 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 					if err := json.Unmarshal([]byte(line), &chunk); err != nil {
 						t.Fatalf("invalid chat NDJSON %q: %v", line, err)
 					}
-					text += chunk.Message.Content
+					text.WriteString(chunk.Message.Content)
 					finalDone = chunk.Done
 				}
-				if text != expectedRainProse {
-					t.Fatalf("rain response = %q, want %q", text, expectedRainProse)
+				responseText := text.String()
+				if responseText != expectedRainProse {
+					t.Fatalf("rain response = %q, want %q", responseText, expectedRainProse)
 				}
-				if words := len(strings.Fields(text)); words != 50 {
-					t.Fatalf("rain response has %d words, want 50: %q", words, text)
+				if words := len(strings.Fields(responseText)); words != 50 {
+					t.Fatalf("rain response has %d words, want 50: %q", words, responseText)
 				}
 				if !finalDone {
 					t.Error("chat stream terminal object has done:false")

--- a/ollama/prompt_fidelity_test.go
+++ b/ollama/prompt_fidelity_test.go
@@ -32,6 +32,8 @@ const (
 	oceanPoemPrompt         = "Write a 4-line poem about the ocean. Rhyming. No introduction."
 	rainProsePrompt         = "Write exactly 50 words of prose about someone walking home in the rain. No introduction, just the prose."
 	chineseGreetingPrompt   = "你好"
+	expectedLighthouseProse = "Each dawn, Mara climbed the lighthouse stairs before the gulls began calling. One stormy morning, a green bottle knocked against the rocks below. Inside, she found a faded message: Keep the lamp dark tonight. Mara read it twice, then watched an unfamiliar ship waiting beyond the reef. At sunset, she covered the lens and held her breath. The ship slipped safely past hidden mines revealed by the falling tide. By midnight, another bottle arrived. Its message contained only three words: Thank you, sister. Mara smiled, relit the lamp, and finally understood why her lost brother had never returned safely home."
+	expectedRainProse       = "Rain followed Maya along the empty streets as she walked home, soaking her coat and blurring every streetlight. She kept one hand over the letter in her pocket. At last, her porch appeared through the silver curtain, and she hurried toward its warm, waiting glow with relief and smiled softly."
 )
 
 func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
@@ -124,14 +126,14 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 				want   string
 			}{
 				{"reverse string", "/api/chat", reverseStringPrompt, "def reverse_string(text):\n    return text[::-1]"},
-				{"lighthouse prose", "/api/chat", lighthousePrompt, ""},
+				{"lighthouse prose", "/api/chat", lighthousePrompt, expectedLighthouseProse},
 				{"arithmetic nonce", "/api/chat", arithmeticNoncePrompt, "391 PINEAPPLE77"},
 				{"prime function", "/api/generate", isPrimePrompt, "def is_prime(n):"},
 				{"one-word greeting", "/api/chat", oneWordGreetingPrompt, "Hi"},
 				{"FizzBuzz function", "/api/chat", fizzBuzzPrompt, "def fizzbuzz():"},
 				{"dictionary sort", "/api/chat", dictSortPrompt, "dict(sorted(my_dict.items(), key=lambda item: item[1], reverse=True))"},
 				{"ocean poem", "/api/chat", oceanPoemPrompt, "Moonlit waves roll softly to the shore,\nThey turn beneath the stars and rise once more.\nThe salt wind sings across the silver sea,\nThe distant tides roll homeward, wild and free."},
-				{"rain prose", "/api/chat", rainProsePrompt, ""},
+				{"rain prose", "/api/chat", rainProsePrompt, expectedRainProse},
 			} {
 				detailed := detailed
 				t.Run("detailed "+detailed.name, func(t *testing.T) {
@@ -158,6 +160,9 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 						text = response.Message.Content
 					}
 					if detailed.name == "lighthouse prose" {
+						if text != detailed.want {
+							t.Fatalf("lighthouse response = %q, want %q", text, detailed.want)
+						}
 						if words := len(strings.Fields(text)); words != 100 {
 							t.Fatalf("lighthouse response has %d words, want 100: %q", words, text)
 						}
@@ -165,6 +170,9 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 							t.Fatalf("negated introduction misclassified: %q", text)
 						}
 					} else if detailed.name == "rain prose" {
+						if text != detailed.want {
+							t.Fatalf("rain response = %q, want %q", text, detailed.want)
+						}
 						if words := len(strings.Fields(text)); words != 50 {
 							t.Fatalf("rain response has %d words, want 50: %q", words, text)
 						}
@@ -207,6 +215,9 @@ func TestObservedPromptsAcrossNativeSurfacesAndAdvertisedModels(t *testing.T) {
 					}
 					text += chunk.Message.Content
 					finalDone = chunk.Done
+				}
+				if text != expectedRainProse {
+					t.Fatalf("rain response = %q, want %q", text, expectedRainProse)
 				}
 				if words := len(strings.Fields(text)); words != 50 {
 					t.Fatalf("rain response has %d words, want 50: %q", words, text)

--- a/vllm/vllm_test.go
+++ b/vllm/vllm_test.go
@@ -59,6 +59,7 @@ func TestChatCompletionRouteIsDynamic(t *testing.T) {
 	}
 }
 
+// TestObservedSeedValidators covers the exact vLLM gates captured in production.
 func TestObservedSeedValidators(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/vllm/vllm_test.go
+++ b/vllm/vllm_test.go
@@ -58,6 +58,63 @@ func TestChatCompletionRouteIsDynamic(t *testing.T) {
 	}
 }
 
+func TestObservedSeedValidators(t *testing.T) {
+	tests := []struct {
+		name   string
+		model  string
+		prompt string
+		want   string
+	}{
+		{
+			name:   "exact hello-world echo",
+			model:  "qwen3.6:27b",
+			prompt: "Reply with exactly: hello world",
+			want:   "hello world",
+		},
+		{
+			name:   "natural-language multiplication",
+			model:  defaultModel,
+			prompt: "Calculate 17 multiplied by 23. Return only the number.",
+			want:   "391",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body, err := json.Marshal(map[string]any{
+				"model":      test.model,
+				"messages":   []map[string]string{{"role": "user", "content": test.prompt}},
+				"max_tokens": 50,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+			buildHandler().ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+			}
+			var response struct {
+				Model   string `json:"model"`
+				Choices []struct {
+					Message struct {
+						Content string `json:"content"`
+					} `json:"message"`
+				} `json:"choices"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("invalid JSON: %v", err)
+			}
+			if response.Model != test.model {
+				t.Errorf("model = %q, want %q", response.Model, test.model)
+			}
+			if len(response.Choices) != 1 || response.Choices[0].Message.Content != test.want {
+				t.Fatalf("response = %s, want content %q", rec.Body.String(), test.want)
+			}
+		})
+	}
+}
+
 func TestHealthOK(t *testing.T) {
 	rec := httptest.NewRecorder()
 	buildHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))

--- a/vllm/vllm_test.go
+++ b/vllm/vllm_test.go
@@ -1,6 +1,7 @@
 package vllm
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,7 +90,7 @@ func TestObservedSeedValidators(t *testing.T) {
 				t.Fatal(err)
 			}
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 			buildHandler().ServeHTTP(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())


### PR DESCRIPTION
## What changed

Adds bounded deterministic responses for seven validator shapes observed in production:

- executable Python FizzBuzz function
- descending dictionary-value sort one-liner
- exactly four rhyming ocean-poem lines
- exactly 50 words of rain prose
- natural Chinese greeting for `你好`
- natural-language multiplication returning only `391`
- bounded exact echo returning `hello world`

All responses reuse existing telemetry kinds; there is no protobuf or server change.

## Production evidence

After release `20260727.30302808470`, three actors sent 33 validators that received `generic_safe`: 24 structured Ollama prompts, six Chinese greetings, two vLLM multiplication prompts, and one exact echo. The structured set was retried on a second sensor, while all three actors stopped without a follow-on payload.

## Validation

- full `go test ./...`
- full `go test -race ./...`
- `go vet ./llmcore ./ollama ./vllm`
- Linux amd64 and 386 cross-builds
- Python execution tests for both code responses
- all six advertised Ollama models and observed Ollama/vLLM routes
- stream terminal framing and exact line/word constraints

Beads: `threat_gg-9fq`