### PR TITLE
fix(mysql): capture the auth credential and every query (threat_gg-cb0)

### DIFF
--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -382,8 +382,43 @@ func TestPersistSessionContinuesAfterAQueryFails(t *testing.T) {
 	}
 }
 
-// A connection that produced neither a username nor a query is an ordinary port scan and
-// must not manufacture an attacker row.
+// TestPersistSessionRecordsAnonymousCredential covers the case the empty-session guard
+// used to swallow. MySQL allows anonymous accounts, so a client can authenticate with an
+// empty username and still send a real native-password response; keying the guard on the
+// username alone threw that credential away for want of a name to file it under.
+func TestPersistSessionRecordsAnonymousCredential(t *testing.T) {
+	rec := withRecorder(t)
+	scramble := make([]byte, 20)
+	authData := make([]byte, 20)
+	for i := range scramble {
+		scramble[i] = byte(i + 7)
+		authData[i] = byte(i + 11)
+	}
+
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000009",
+		remoteIP: "203.0.113.15",
+		scramble: scramble,
+		authData: authData,
+	})
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.logins) != 1 {
+		t.Fatalf("logins = %d, want 1 for an anonymous login carrying a credential", len(rec.logins))
+	}
+	want := "$mysqlna$" + hex.EncodeToString(scramble) + "*" + hex.EncodeToString(authData)
+	if got := rec.logins[0].Password; got != want {
+		t.Errorf("password = %q, want %q", got, want)
+	}
+	if rec.logins[0].Username != "" {
+		t.Errorf("username = %q, want empty", rec.logins[0].Username)
+	}
+}
+
+// A connection that produced nothing at all -- no username, no credential, no query -- is
+// an ordinary port scan and must not manufacture an attacker row.
 func TestPersistSessionSkipsEmptySessions(t *testing.T) {
 	rec := withRecorder(t)
 	h := &honeypot{}

--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -43,7 +43,7 @@ func TestNativePasswordArtifact(t *testing.T) {
 func TestNativePasswordArtifactRejectsUnusableInput(t *testing.T) {
 	full := make([]byte, 20)
 	cases := []struct {
-		name              string
+		name               string
 		scramble, authData []byte
 	}{
 		// An empty auth response is an anonymous / no-password login, not a credential.
@@ -91,9 +91,9 @@ func TestSendHandshakeReturnsScramble(t *testing.T) {
 }
 
 type recorder struct {
-	mu     sync.Mutex
-	logins []*proto.MysqlRequest
-	querys []*proto.QueryRequest
+	mu      sync.Mutex
+	logins  []*proto.MysqlRequest
+	queries []*proto.QueryRequest
 }
 
 func (r *recorder) login(in *proto.MysqlRequest) error {
@@ -106,7 +106,7 @@ func (r *recorder) login(in *proto.MysqlRequest) error {
 func (r *recorder) query(in *proto.QueryRequest) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.querys = append(r.querys, in)
+	r.queries = append(r.queries, in)
 	return nil
 }
 
@@ -157,10 +157,10 @@ func TestPersistSessionSavesPasswordAndQueries(t *testing.T) {
 		t.Errorf("password = %q, want %q", login.Password, want)
 	}
 
-	if len(rec.querys) != 3 {
-		t.Fatalf("queries saved = %d, want 3", len(rec.querys))
+	if len(rec.queries) != 3 {
+		t.Fatalf("queries saved = %d, want 3", len(rec.queries))
 	}
-	for i, q := range rec.querys {
+	for i, q := range rec.queries {
 		if q.CommandType != "mysql" {
 			t.Errorf("query %d command_type = %q, want mysql (the server rejects anything else)", i, q.CommandType)
 		}
@@ -170,7 +170,7 @@ func TestPersistSessionSavesPasswordAndQueries(t *testing.T) {
 	}
 	// The credential-setting statement is the highest-value capture and used to be the
 	// one guaranteed to be dropped, because the only telemetry path skipped it.
-	if got := rec.querys[1].Query; got != "CREATE USER 'evil'@'%' IDENTIFIED BY 'hunter2'" {
+	if got := rec.queries[1].Query; got != "CREATE USER 'evil'@'%' IDENTIFIED BY 'hunter2'" {
 		t.Errorf("credential statement not captured verbatim, got %q", got)
 	}
 }
@@ -192,8 +192,8 @@ func TestPersistSessionSkipsQueriesWhenLoginFails(t *testing.T) {
 		queries:  []string{"select 1"},
 	})
 
-	if len(rec.querys) != 0 {
-		t.Errorf("queries saved = %d, want 0 when the login failed", len(rec.querys))
+	if len(rec.queries) != 0 {
+		t.Errorf("queries saved = %d, want 0 when the login failed", len(rec.queries))
 	}
 }
 
@@ -202,8 +202,8 @@ func TestPersistSessionSkipsEmptySessions(t *testing.T) {
 	h := &honeypot{}
 	h.persistSession(&session{guid: "3f2a1b4c-0000-4000-8000-000000000003", remoteIP: "203.0.113.9"})
 
-	if len(rec.logins) != 0 || len(rec.querys) != 0 {
-		t.Errorf("bare connection persisted: %d logins, %d queries", len(rec.logins), len(rec.querys))
+	if len(rec.logins) != 0 || len(rec.queries) != 0 {
+		t.Errorf("bare connection persisted: %d logins, %d queries", len(rec.logins), len(rec.queries))
 	}
 }
 

--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -429,8 +429,9 @@ func TestPersistSessionSkipsEmptySessions(t *testing.T) {
 	}
 }
 
-// A login that supplies no password must still record the session; it just carries no
-// credential artifact.
+// A named user who supplies no password must still record the session; it just carries no
+// credential artifact. Distinct from TestPersistSessionRecordsAnonymousCredential above,
+// which is the mirror image: no username, but a credential.
 func TestPersistSessionNoPasswordLoginHasEmptyPassword(t *testing.T) {
 	rec := withRecorder(t)
 	h := &honeypot{}
@@ -445,6 +446,6 @@ func TestPersistSessionNoPasswordLoginHasEmptyPassword(t *testing.T) {
 		t.Fatalf("logins saved = %d, want 1", len(rec.logins))
 	}
 	if rec.logins[0].Password != "" {
-		t.Errorf("password = %q, want empty for an anonymous login", rec.logins[0].Password)
+		t.Errorf("password = %q, want empty when the client sent no auth response", rec.logins[0].Password)
 	}
 }

--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -1,0 +1,227 @@
+package mysql
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+)
+
+// threat_gg-cb0. The MySQL honeypot parsed the client's auth response and every query
+// and then threw both away: persistSession hardcoded Password: "" and sess.queries was
+// only ever counted for a log line. Production confirmed it -- 68 captured usernames and
+// zero passwords, against 2,320 for mssql.
+//
+// These tests pin the two capture paths and the credential format.
+
+// TestNativePasswordArtifact covers the format decision. A mysql_native_password reply is
+// SHA1(pw) XOR SHA1(scramble || SHA1(SHA1(pw))), so the client's 20 bytes are worthless on
+// their own -- cracking needs the server scramble that produced them, which the honeypot
+// used to generate and discard. We emit both in hashcat's -m 11200 format so the artifact
+// is self-describing (nobody mistakes it for a plaintext password) and directly usable.
+func TestNativePasswordArtifact(t *testing.T) {
+	scramble := make([]byte, 20)
+	authData := make([]byte, 20)
+	for i := range scramble {
+		scramble[i] = byte(i)
+		authData[i] = byte(0xF0 + i%16)
+	}
+
+	got := nativePasswordArtifact(scramble, authData)
+	want := "$mysqlna$" + hex.EncodeToString(scramble) + "*" + hex.EncodeToString(authData)
+	if got != want {
+		t.Errorf("artifact = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, "$mysqlna$") {
+		t.Error("artifact must carry the $mysqlna$ tag so it is never read as a plaintext password")
+	}
+}
+
+func TestNativePasswordArtifactRejectsUnusableInput(t *testing.T) {
+	full := make([]byte, 20)
+	cases := []struct {
+		name              string
+		scramble, authData []byte
+	}{
+		// An empty auth response is an anonymous / no-password login, not a credential.
+		{"empty auth response", full, nil},
+		// Without the scramble the response cannot be cracked, so emitting it would imply
+		// a usable artifact we do not have.
+		{"missing scramble", nil, full},
+		// Any length but 20 means the client negotiated a different auth plugin
+		// (caching_sha2_password, etc.); the mysqlna format would be a lie.
+		{"short auth response", full, make([]byte, 8)},
+		{"long auth response", full, make([]byte, 32)},
+		{"short scramble", make([]byte, 8), full},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := nativePasswordArtifact(c.scramble, c.authData); got != "" {
+				t.Errorf("artifact = %q, want empty", got)
+			}
+		})
+	}
+}
+
+// TestSendHandshakeReturnsScramble pins the plumbing the artifact depends on: the scramble
+// must escape sendHandshake, since it is generated per connection and is otherwise lost.
+func TestSendHandshakeReturnsScramble(t *testing.T) {
+	var first, second strings.Builder
+	s1, err := sendHandshake(&first, 1)
+	if err != nil {
+		t.Fatalf("sendHandshake: %v", err)
+	}
+	if len(s1) != 20 {
+		t.Fatalf("scramble length = %d, want 20", len(s1))
+	}
+	if !strings.Contains(first.String(), string(s1[:8])) {
+		t.Error("the returned scramble is not the one written in the greeting")
+	}
+
+	s2, err := sendHandshake(&second, 2)
+	if err != nil {
+		t.Fatalf("sendHandshake: %v", err)
+	}
+	if string(s1) == string(s2) {
+		t.Error("scramble must be per-connection; a fixed salt makes every capture correlatable")
+	}
+}
+
+type recorder struct {
+	mu     sync.Mutex
+	logins []*proto.MysqlRequest
+	querys []*proto.QueryRequest
+}
+
+func (r *recorder) login(in *proto.MysqlRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.logins = append(r.logins, in)
+	return nil
+}
+
+func (r *recorder) query(in *proto.QueryRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.querys = append(r.querys, in)
+	return nil
+}
+
+func withRecorder(t *testing.T) *recorder {
+	t.Helper()
+	rec := &recorder{}
+	origLogin, origQuery := saveMysqlLogin, saveQuery
+	saveMysqlLogin, saveQuery = rec.login, rec.query
+	t.Cleanup(func() { saveMysqlLogin, saveQuery = origLogin, origQuery })
+	return rec
+}
+
+func TestPersistSessionSavesPasswordAndQueries(t *testing.T) {
+	rec := withRecorder(t)
+	h := &honeypot{}
+
+	scramble := make([]byte, 20)
+	authData := make([]byte, 20)
+	for i := range scramble {
+		scramble[i] = byte(i + 1)
+		authData[i] = byte(i + 100)
+	}
+
+	sess := &session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000001",
+		username: "root",
+		database: "mysql",
+		remoteIP: "203.0.113.7",
+		scramble: scramble,
+		authData: authData,
+		queries: []string{
+			"select @@version",
+			"CREATE USER 'evil'@'%' IDENTIFIED BY 'hunter2'",
+			"USE information_schema",
+		},
+	}
+	h.persistSession(sess)
+
+	if len(rec.logins) != 1 {
+		t.Fatalf("logins saved = %d, want 1", len(rec.logins))
+	}
+	login := rec.logins[0]
+	if login.Username != "root" || login.RemoteAddr != "203.0.113.7" || login.Guid != sess.guid {
+		t.Errorf("login fields wrong: %+v", login)
+	}
+	want := "$mysqlna$" + hex.EncodeToString(scramble) + "*" + hex.EncodeToString(authData)
+	if login.Password != want {
+		t.Errorf("password = %q, want %q", login.Password, want)
+	}
+
+	if len(rec.querys) != 3 {
+		t.Fatalf("queries saved = %d, want 3", len(rec.querys))
+	}
+	for i, q := range rec.querys {
+		if q.CommandType != "mysql" {
+			t.Errorf("query %d command_type = %q, want mysql (the server rejects anything else)", i, q.CommandType)
+		}
+		if q.Guid != sess.guid {
+			t.Errorf("query %d guid = %q, want %q", i, q.Guid, sess.guid)
+		}
+	}
+	// The credential-setting statement is the highest-value capture and used to be the
+	// one guaranteed to be dropped, because the only telemetry path skipped it.
+	if got := rec.querys[1].Query; got != "CREATE USER 'evil'@'%' IDENTIFIED BY 'hunter2'" {
+		t.Errorf("credential statement not captured verbatim, got %q", got)
+	}
+}
+
+// TestPersistSessionSkipsQueriesWhenLoginFails keeps command rows from being orphaned:
+// the server derives the attacker row from the login, so a command saved without one
+// would reference a guid that never materializes.
+func TestPersistSessionSkipsQueriesWhenLoginFails(t *testing.T) {
+	rec := withRecorder(t)
+	origLogin := saveMysqlLogin
+	saveMysqlLogin = func(*proto.MysqlRequest) error { return errors.New("grpc down") }
+	t.Cleanup(func() { saveMysqlLogin = origLogin })
+
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000002",
+		username: "root",
+		remoteIP: "203.0.113.8",
+		queries:  []string{"select 1"},
+	})
+
+	if len(rec.querys) != 0 {
+		t.Errorf("queries saved = %d, want 0 when the login failed", len(rec.querys))
+	}
+}
+
+func TestPersistSessionSkipsEmptySessions(t *testing.T) {
+	rec := withRecorder(t)
+	h := &honeypot{}
+	h.persistSession(&session{guid: "3f2a1b4c-0000-4000-8000-000000000003", remoteIP: "203.0.113.9"})
+
+	if len(rec.logins) != 0 || len(rec.querys) != 0 {
+		t.Errorf("bare connection persisted: %d logins, %d queries", len(rec.logins), len(rec.querys))
+	}
+}
+
+// A no-password login must still record the session; it just carries no credential.
+func TestPersistSessionAnonymousLoginHasEmptyPassword(t *testing.T) {
+	rec := withRecorder(t)
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000004",
+		username: "root",
+		remoteIP: "203.0.113.10",
+		scramble: make([]byte, 20),
+	})
+
+	if len(rec.logins) != 1 {
+		t.Fatalf("logins saved = %d, want 1", len(rec.logins))
+	}
+	if rec.logins[0].Password != "" {
+		t.Errorf("password = %q, want empty for an anonymous login", rec.logins[0].Password)
+	}
+}

--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -197,6 +197,42 @@ func TestPersistSessionSkipsQueriesWhenLoginFails(t *testing.T) {
 	}
 }
 
+// One failing SaveQuery must not abandon the rest of the session: the interesting
+// statement is as likely to be the last as the first.
+func TestPersistSessionContinuesAfterAQueryFails(t *testing.T) {
+	rec := withRecorder(t)
+	origQuery := saveQuery
+	var calls int
+	saveQuery = func(in *proto.QueryRequest) error {
+		calls++
+		if calls == 2 {
+			return errors.New("transient grpc failure")
+		}
+		return rec.query(in)
+	}
+	t.Cleanup(func() { saveQuery = origQuery })
+
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000005",
+		username: "root",
+		remoteIP: "203.0.113.11",
+		queries:  []string{"select 1", "select 2", "DROP TABLE users"},
+	})
+
+	if calls != 3 {
+		t.Errorf("SaveQuery called %d times, want 3 (the loop must not abort on error)", calls)
+	}
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.queries) != 2 {
+		t.Fatalf("queries recorded = %d, want 2 (the middle one failed)", len(rec.queries))
+	}
+	if rec.queries[1].Query != "DROP TABLE users" {
+		t.Errorf("the query after the failure was lost; got %q", rec.queries[1].Query)
+	}
+}
+
 func TestPersistSessionSkipsEmptySessions(t *testing.T) {
 	rec := withRecorder(t)
 	h := &honeypot{}
@@ -207,8 +243,9 @@ func TestPersistSessionSkipsEmptySessions(t *testing.T) {
 	}
 }
 
-// A no-password login must still record the session; it just carries no credential.
-func TestPersistSessionAnonymousLoginHasEmptyPassword(t *testing.T) {
+// A login that supplies no password must still record the session; it just carries no
+// credential artifact.
+func TestPersistSessionNoPasswordLoginHasEmptyPassword(t *testing.T) {
 	rec := withRecorder(t)
 	h := &honeypot{}
 	h.persistSession(&session{

--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -40,6 +40,9 @@ func TestNativePasswordArtifact(t *testing.T) {
 	}
 }
 
+// TestNativePasswordArtifactRejectsUnusableInput pins the cases where we hold half an
+// exchange or something that is not one at all, and must say so by storing nothing rather
+// than inventing a credential.
 func TestNativePasswordArtifactRejectsUnusableInput(t *testing.T) {
 	full := make([]byte, 20)
 	cases := []struct {
@@ -280,6 +283,41 @@ func TestPersistSessionAbandonsQueriesWhenTheBackendIsDown(t *testing.T) {
 	}
 }
 
+// TestPersistSessionResetsFailureCountOnSuccess proves the counter is consecutive rather
+// than cumulative. Without the reset, scattered transient failures would eventually add up
+// to the abandon threshold and silently truncate a session that was persisting fine.
+func TestPersistSessionResetsFailureCountOnSuccess(t *testing.T) {
+	rec := withRecorder(t)
+	origQuery := saveQuery
+	var calls int
+	saveQuery = func(in *proto.QueryRequest) error {
+		calls++
+		// Fail on every other call: never three in a row, so the loop must run to the end.
+		if calls%2 == 1 {
+			return errors.New("transient grpc failure")
+		}
+		return rec.query(in)
+	}
+	t.Cleanup(func() { saveQuery = origQuery })
+
+	queries := make([]string, 9)
+	for i := range queries {
+		queries[i] = "select 1"
+	}
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000008",
+		username: "root",
+		remoteIP: "203.0.113.14",
+		queries:  queries,
+	})
+
+	if calls != len(queries) {
+		t.Errorf("SaveQuery called %d times, want %d; interleaved failures must not accumulate "+
+			"toward the abandon threshold", calls, len(queries))
+	}
+}
+
 // TestPersistSessionRecordsQueryOnlySessions covers the documented case where a session
 // produced queries but no username: the guard keeps it, since an unauthenticated query is
 // still worth having.
@@ -344,6 +382,8 @@ func TestPersistSessionContinuesAfterAQueryFails(t *testing.T) {
 	}
 }
 
+// A connection that produced neither a username nor a query is an ordinary port scan and
+// must not manufacture an attacker row.
 func TestPersistSessionSkipsEmptySessions(t *testing.T) {
 	rec := withRecorder(t)
 	h := &honeypot{}

--- a/mysql/capture_test.go
+++ b/mysql/capture_test.go
@@ -30,7 +30,7 @@ func TestNativePasswordArtifact(t *testing.T) {
 		authData[i] = byte(0xF0 + i%16)
 	}
 
-	got := nativePasswordArtifact(scramble, authData)
+	got := nativePasswordArtifact(scramble, authData, "")
 	want := "$mysqlna$" + hex.EncodeToString(scramble) + "*" + hex.EncodeToString(authData)
 	if got != want {
 		t.Errorf("artifact = %q, want %q", got, want)
@@ -59,10 +59,54 @@ func TestNativePasswordArtifactRejectsUnusableInput(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := nativePasswordArtifact(c.scramble, c.authData); got != "" {
+			if got := nativePasswordArtifact(c.scramble, c.authData, ""); got != "" {
 				t.Errorf("artifact = %q, want empty", got)
 			}
 		})
+	}
+}
+
+// TestNativePasswordArtifactRejectsOtherPlugins is the reason the artifact takes the
+// negotiated plugin rather than trusting the 20-byte length. mysql_clear_password sends
+// the password itself: a 20-character one would otherwise be hex-encoded under a
+// $mysqlna$ label, mislabelling a plaintext as a digest and burying it from anyone
+// reading the column.
+func TestNativePasswordArtifactRejectsOtherPlugins(t *testing.T) {
+	scramble := make([]byte, 20)
+	clearPassword := []byte("correcthorsebattery1") // exactly 20 bytes
+	for i := range scramble {
+		scramble[i] = byte(i)
+	}
+
+	for _, plugin := range []string{"mysql_clear_password", "caching_sha2_password", "sha256_password"} {
+		t.Run(plugin, func(t *testing.T) {
+			if got := nativePasswordArtifact(scramble, clearPassword, plugin); got != "" {
+				t.Errorf("artifact = %q, want empty for plugin %q", got, plugin)
+			}
+		})
+	}
+
+	// The plugin we actually advertise, and a client that names none, both stand.
+	for _, plugin := range []string{"", authPluginName} {
+		if got := nativePasswordArtifact(scramble, clearPassword, plugin); got == "" {
+			t.Errorf("artifact empty for plugin %q, want the mysqlna form", plugin)
+		}
+	}
+}
+
+// TestParseHandshakeResponseReadsAuthPlugin pins the parsing the check above depends on.
+func TestParseHandshakeResponseReadsAuthPlugin(t *testing.T) {
+	authData := make([]byte, 20)
+	pkt := buildClientAuthPacket("root", authData)
+	pkt = append(pkt, "mysql_clear_password"...)
+	pkt = append(pkt, 0x00)
+
+	creds := parseHandshakeResponse(pkt)
+	if creds.authPlugin != "mysql_clear_password" {
+		t.Errorf("authPlugin = %q, want mysql_clear_password", creds.authPlugin)
+	}
+	if creds.username != "root" {
+		t.Errorf("username = %q, want root", creds.username)
 	}
 }
 
@@ -181,7 +225,11 @@ func TestPersistSessionSavesPasswordAndQueries(t *testing.T) {
 func TestPersistSessionSkipsQueriesWhenLoginFails(t *testing.T) {
 	rec := withRecorder(t)
 	origLogin := saveMysqlLogin
-	saveMysqlLogin = func(*proto.MysqlRequest) error { return errors.New("grpc down") }
+	var loginCalls int
+	saveMysqlLogin = func(*proto.MysqlRequest) error {
+		loginCalls++
+		return errors.New("grpc down")
+	}
 	t.Cleanup(func() { saveMysqlLogin = origLogin })
 
 	h := &honeypot{}
@@ -192,8 +240,71 @@ func TestPersistSessionSkipsQueriesWhenLoginFails(t *testing.T) {
 		queries:  []string{"select 1"},
 	})
 
+	if loginCalls != 1 {
+		t.Errorf("SaveMysqlLogin called %d times, want 1; the test must exercise the failing "+
+			"login rather than pass by returning before it", loginCalls)
+	}
 	if len(rec.queries) != 0 {
 		t.Errorf("queries saved = %d, want 0 when the login failed", len(rec.queries))
+	}
+}
+
+// TestPersistSessionAbandonsQueriesWhenTheBackendIsDown bounds the persistence goroutine.
+// Without it, a session holding maxCommands queries against a stalled backend would work
+// through every one at saveTimeout apiece -- roughly 42 minutes of retained goroutine and
+// captured payload for no successful write.
+func TestPersistSessionAbandonsQueriesWhenTheBackendIsDown(t *testing.T) {
+	withRecorder(t)
+	origQuery := saveQuery
+	var calls int
+	saveQuery = func(*proto.QueryRequest) error {
+		calls++
+		return errors.New("backend unavailable")
+	}
+	t.Cleanup(func() { saveQuery = origQuery })
+
+	queries := make([]string, 50)
+	for i := range queries {
+		queries[i] = "select 1"
+	}
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000006",
+		username: "root",
+		remoteIP: "203.0.113.12",
+		queries:  queries,
+	})
+
+	if calls != maxConsecutivePersistFailures {
+		t.Errorf("SaveQuery called %d times, want %d before abandoning", calls, maxConsecutivePersistFailures)
+	}
+}
+
+// TestPersistSessionRecordsQueryOnlySessions covers the documented case where a session
+// produced queries but no username: the guard keeps it, since an unauthenticated query is
+// still worth having.
+func TestPersistSessionRecordsQueryOnlySessions(t *testing.T) {
+	rec := withRecorder(t)
+	h := &honeypot{}
+	h.persistSession(&session{
+		guid:     "3f2a1b4c-0000-4000-8000-000000000007",
+		remoteIP: "203.0.113.13",
+		queries:  []string{"select @@version"},
+	})
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.logins) != 1 {
+		t.Fatalf("logins = %d, want 1 for a query-only session", len(rec.logins))
+	}
+	if len(rec.queries) != 1 {
+		t.Fatalf("queries = %d, want 1", len(rec.queries))
+	}
+	if rec.logins[0].Username != "" || rec.logins[0].Password != "" {
+		t.Errorf("query-only login should carry no credential, got %+v", rec.logins[0])
+	}
+	if rec.queries[0].Guid != rec.logins[0].Guid {
+		t.Errorf("query guid %q does not match login guid %q", rec.queries[0].Guid, rec.logins[0].Guid)
 	}
 }
 

--- a/mysql/connection_capture_test.go
+++ b/mysql/connection_capture_test.go
@@ -1,0 +1,157 @@
+package mysql
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/hex"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// threat_gg-cb0 follow-up. The unit tests in capture_test.go build a session by hand, so
+// they prove persistSession's behaviour but NOT the wiring that fills it in: if
+// handleConnection stopped assigning sess.scramble or sess.authData, every one of them
+// would still pass while production captured nothing again -- the exact failure this issue
+// exists to fix.
+//
+// This drives a real connection end to end over net.Pipe and asserts that the scramble the
+// server actually put on the wire, and the auth reply the client actually sent, are the
+// two halves of the stored credential.
+func TestConnectionCapturesCredentialAndQuery(t *testing.T) {
+	rec := withRecorder(t)
+	done := make(chan struct{})
+
+	server, client := net.Pipe()
+	h := &honeypot{logger: zerolog.Nop()}
+	go func() {
+		h.handleConnection(server)
+		close(done)
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+	reader := bufio.NewReader(client)
+
+	greeting, _, err := readPacket(reader)
+	if err != nil {
+		t.Fatalf("read greeting: %v", err)
+	}
+	// Scramble part 1 sits after: protocol version (1), server version + NUL, conn id (4).
+	scrambleP1Offset := 1 + len(serverVersion) + 1 + 4
+	if len(greeting) < scrambleP1Offset+8 {
+		t.Fatalf("greeting too short: %d bytes", len(greeting))
+	}
+	advertised := greeting[scrambleP1Offset : scrambleP1Offset+8]
+
+	authData := make([]byte, 20)
+	for i := range authData {
+		authData[i] = byte(0xA0 + i)
+	}
+	if err := writePacket(client, 1, buildClientAuthPacket("root", authData)); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+	if _, _, err := readPacket(reader); err != nil { // server OK
+		t.Fatalf("read auth OK: %v", err)
+	}
+
+	const query = "CREATE USER 'evil'@'%' IDENTIFIED BY 'hunter2'"
+	if err := writePacket(client, 0, append([]byte{comQuery}, query...)); err != nil {
+		t.Fatalf("write query: %v", err)
+	}
+	if _, _, err := readPacket(reader); err != nil {
+		t.Fatalf("read query response: %v", err)
+	}
+	if err := writePacket(client, 0, []byte{comQuit}); err != nil {
+		t.Fatalf("write quit: %v", err)
+	}
+
+	<-done
+	client.Close()
+	waitFor(t, func() bool {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		return len(rec.logins) == 1 && len(rec.queries) == 1
+	}, "login and query to be persisted")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	login := rec.logins[0]
+	if login.Username != "root" {
+		t.Errorf("username = %q, want root", login.Username)
+	}
+	if !strings.HasPrefix(login.Password, "$mysqlna$") {
+		t.Fatalf("password = %q, want a $mysqlna$ artifact", login.Password)
+	}
+	// The stored scramble must be the one this connection advertised, not a fresh or zero
+	// value: that is what makes the captured reply crackable.
+	if !strings.HasPrefix(login.Password, "$mysqlna$"+hex.EncodeToString(advertised)) {
+		t.Errorf("stored scramble does not match the greeting; password = %q, greeting scramble starts %s",
+			login.Password, hex.EncodeToString(advertised))
+	}
+	if !strings.HasSuffix(login.Password, "*"+hex.EncodeToString(authData)) {
+		t.Errorf("stored response does not match what the client sent; password = %q", login.Password)
+	}
+	if got := rec.queries[0]; got.Query != query || got.CommandType != "mysql" || got.Guid != login.Guid {
+		t.Errorf("query captured as %+v, want %q/mysql sharing the login guid", got, query)
+	}
+}
+
+// A connection that opens and disconnects without authenticating must still persist
+// nothing, so ordinary port scans do not manufacture attacker rows.
+func TestConnectionWithoutAuthPersistsNothing(t *testing.T) {
+	rec := withRecorder(t)
+	done := make(chan struct{})
+
+	server, client := net.Pipe()
+	h := &honeypot{logger: zerolog.Nop()}
+	go func() {
+		h.handleConnection(server)
+		close(done)
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, _, err := readPacket(bufio.NewReader(client)); err != nil {
+		t.Fatalf("read greeting: %v", err)
+	}
+	client.Close()
+	<-done
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.logins) != 0 || len(rec.queries) != 0 {
+		t.Errorf("bare scan persisted %d logins, %d queries", len(rec.logins), len(rec.queries))
+	}
+}
+
+// buildClientAuthPacket assembles the HandshakeResponse41 layout parseHandshakeResponse
+// expects: 4 capability bytes, 4 max-packet bytes, 1 charset byte, 23 reserved, the
+// null-terminated username, then a length-prefixed auth response.
+func buildClientAuthPacket(username string, authData []byte) []byte {
+	buf := make([]byte, 0, 64)
+	caps := make([]byte, 4)
+	binary.LittleEndian.PutUint32(caps, clientProtocol41|clientSecureConn|clientPluginAuth)
+	buf = append(buf, caps...)
+	buf = append(buf, make([]byte, 4)...) // max packet size
+	buf = append(buf, charsetUTF8MB4)
+	buf = append(buf, make([]byte, 23)...) // reserved
+	buf = append(buf, username...)
+	buf = append(buf, 0x00)
+	buf = append(buf, byte(len(authData)))
+	buf = append(buf, authData...)
+	return buf
+}
+
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/mysql/connection_capture_test.go
+++ b/mysql/connection_capture_test.go
@@ -143,6 +143,54 @@ func TestConnectionCapturesCredentialWhenClientHangsUpAfterAuth(t *testing.T) {
 	}
 }
 
+// TestConnectionWithClearPasswordPluginStoresNoArtifact is the end-to-end half of the
+// plugin check. The helper-level tests prove nativePasswordArtifact rejects a non-native
+// plugin, but only a real connection proves creds.authPlugin actually survives parsing and
+// reaches persistSession: drop that one assignment and a 20-byte mysql_clear_password
+// reply -- the password itself -- would be stored as a crackable $mysqlna$ digest.
+func TestConnectionWithClearPasswordPluginStoresNoArtifact(t *testing.T) {
+	rec := withRecorder(t)
+	done := make(chan struct{})
+
+	server, client := net.Pipe()
+	h := &honeypot{logger: zerolog.Nop()}
+	go func() {
+		h.handleConnection(server)
+		close(done)
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, _, err := readPacket(bufio.NewReader(client)); err != nil {
+		t.Fatalf("read greeting: %v", err)
+	}
+
+	// Exactly 20 bytes, so only the plugin name distinguishes it from a native digest.
+	clearPassword := []byte("correcthorsebattery1")
+	pkt := buildClientAuthPacket("root", clearPassword)
+	pkt = append(pkt, "mysql_clear_password"...)
+	pkt = append(pkt, 0x00)
+	if err := writePacket(client, 1, pkt); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+	client.Close()
+	<-done
+
+	waitFor(t, func() bool {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		return len(rec.logins) == 1
+	}, "the session to be persisted")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if got := rec.logins[0].Password; got != "" {
+		t.Errorf("password = %q, want empty: a clear-password reply must never be labelled a hash", got)
+	}
+	if rec.logins[0].Username != "root" {
+		t.Errorf("username = %q, want root (the session is still worth recording)", rec.logins[0].Username)
+	}
+}
+
 // A connection that opens and disconnects without authenticating must still persist
 // nothing, so ordinary port scans do not manufacture attacker rows.
 func TestConnectionWithoutAuthPersistsNothing(t *testing.T) {

--- a/mysql/connection_capture_test.go
+++ b/mysql/connection_capture_test.go
@@ -39,12 +39,7 @@ func TestConnectionCapturesCredentialAndQuery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read greeting: %v", err)
 	}
-	// Scramble part 1 sits after: protocol version (1), server version + NUL, conn id (4).
-	scrambleP1Offset := 1 + len(serverVersion) + 1 + 4
-	if len(greeting) < scrambleP1Offset+8 {
-		t.Fatalf("greeting too short: %d bytes", len(greeting))
-	}
-	advertised := greeting[scrambleP1Offset : scrambleP1Offset+8]
+	advertised := scrambleFromGreeting(t, greeting)
 
 	authData := make([]byte, 20)
 	for i := range authData {
@@ -85,17 +80,66 @@ func TestConnectionCapturesCredentialAndQuery(t *testing.T) {
 	if !strings.HasPrefix(login.Password, "$mysqlna$") {
 		t.Fatalf("password = %q, want a $mysqlna$ artifact", login.Password)
 	}
-	// The stored scramble must be the one this connection advertised, not a fresh or zero
-	// value: that is what makes the captured reply crackable.
-	if !strings.HasPrefix(login.Password, "$mysqlna$"+hex.EncodeToString(advertised)) {
-		t.Errorf("stored scramble does not match the greeting; password = %q, greeting scramble starts %s",
-			login.Password, hex.EncodeToString(advertised))
-	}
-	if !strings.HasSuffix(login.Password, "*"+hex.EncodeToString(authData)) {
-		t.Errorf("stored response does not match what the client sent; password = %q", login.Password)
+	// The stored artifact must be the full 20-byte scramble this connection advertised
+	// paired with the exact reply the client sent. Asserting the whole value rather than a
+	// prefix matters: a regression that kept the first 8 bytes but corrupted bytes 9-20
+	// would still yield an uncrackable credential.
+	want := "$mysqlna$" + hex.EncodeToString(advertised) + "*" + hex.EncodeToString(authData)
+	if login.Password != want {
+		t.Errorf("password = %q, want %q", login.Password, want)
 	}
 	if got := rec.queries[0]; got.Query != query || got.CommandType != "mysql" || got.Guid != login.Guid {
 		t.Errorf("query captured as %+v, want %q/mysql sharing the login guid", got, query)
+	}
+}
+
+// TestConnectionCapturesCredentialWhenClientHangsUpAfterAuth covers the case worth the
+// most: a credential-spraying scanner sends its auth response and closes without waiting
+// for the reply. Writing the OK packet then fails, and the bare return that used to follow
+// skipped persistence entirely -- losing the credential precisely where we most want it.
+func TestConnectionCapturesCredentialWhenClientHangsUpAfterAuth(t *testing.T) {
+	rec := withRecorder(t)
+	done := make(chan struct{})
+
+	server, client := net.Pipe()
+	h := &honeypot{logger: zerolog.Nop()}
+	go func() {
+		h.handleConnection(server)
+		close(done)
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+	greeting, _, err := readPacket(bufio.NewReader(client))
+	if err != nil {
+		t.Fatalf("read greeting: %v", err)
+	}
+	advertised := scrambleFromGreeting(t, greeting)
+
+	authData := make([]byte, 20)
+	for i := range authData {
+		authData[i] = byte(i + 3)
+	}
+	if err := writePacket(client, 1, buildClientAuthPacket("admin", authData)); err != nil {
+		t.Fatalf("write auth: %v", err)
+	}
+	// Hang up without reading the OK packet.
+	client.Close()
+	<-done
+
+	waitFor(t, func() bool {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		return len(rec.logins) == 1
+	}, "the credential to be persisted despite the client hanging up")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	want := "$mysqlna$" + hex.EncodeToString(advertised) + "*" + hex.EncodeToString(authData)
+	if got := rec.logins[0].Password; got != want {
+		t.Errorf("password = %q, want %q", got, want)
+	}
+	if rec.logins[0].Username != "admin" {
+		t.Errorf("username = %q, want admin", rec.logins[0].Username)
 	}
 }
 
@@ -124,6 +168,26 @@ func TestConnectionWithoutAuthPersistsNothing(t *testing.T) {
 	if len(rec.logins) != 0 || len(rec.queries) != 0 {
 		t.Errorf("bare scan persisted %d logins, %d queries", len(rec.logins), len(rec.queries))
 	}
+}
+
+// scrambleFromGreeting reassembles the full 20-byte scramble a HandshakeV10 greeting
+// advertises. MySQL splits it: 8 bytes early, the remaining 12 after the status and
+// capability fields, which is why a test that reads only the first fragment can miss a
+// corrupted tail.
+func scrambleFromGreeting(t *testing.T, greeting []byte) []byte {
+	t.Helper()
+	// part 1: protocol version (1) + server version + NUL + connection id (4)
+	p1 := 1 + len(serverVersion) + 1 + 4
+	// part 2: part 1 (8) + filler (1) + capability low (2) + charset (1) +
+	//         status (2) + capability high (2) + auth data length (1) + reserved (10)
+	p2 := p1 + 8 + 1 + 2 + 1 + 2 + 2 + 1 + 10
+	if len(greeting) < p2+12 {
+		t.Fatalf("greeting too short to hold a scramble: %d bytes", len(greeting))
+	}
+	full := make([]byte, 0, 20)
+	full = append(full, greeting[p1:p1+8]...)
+	full = append(full, greeting[p2:p2+12]...)
+	return full
 }
 
 // buildClientAuthPacket assembles the HandshakeResponse41 layout parseHandshakeResponse

--- a/mysql/handshake.go
+++ b/mysql/handshake.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"encoding/hex"
 	"io"
 )
 
@@ -32,11 +33,15 @@ type credentials struct {
 	authData []byte
 }
 
-// buildHandshakeV10 constructs the server greeting packet.
-func buildHandshakeV10(connID uint32) ([]byte, error) {
+// buildHandshakeV10 constructs the server greeting packet and returns the per-connection
+// scramble it embedded. The scramble is returned rather than kept internal because the
+// client's auth reply is only meaningful when paired with it: mysql_native_password sends
+// SHA1(pw) XOR SHA1(scramble || SHA1(SHA1(pw))), so the reply alone cannot be cracked.
+// See nativePasswordArtifact (threat_gg-cb0).
+func buildHandshakeV10(connID uint32) ([]byte, []byte, error) {
 	scramble := make([]byte, 20)
 	if _, err := rand.Read(scramble); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	capabilities := clientProtocol41 | clientSecureConn | clientPluginAuth | clientConnectWithDB
@@ -89,7 +94,7 @@ func buildHandshakeV10(connID uint32) ([]byte, error) {
 	buf = append(buf, authPluginName...)
 	buf = append(buf, 0x00)
 
-	return buf, nil
+	return buf, scramble, nil
 }
 
 // parseHandshakeResponse extracts credentials from the client's auth packet.
@@ -151,10 +156,33 @@ func parseHandshakeResponse(payload []byte) credentials {
 }
 
 // sendHandshake writes the HandshakeV10 greeting to the connection.
-func sendHandshake(w io.Writer, connID uint32) error {
-	greeting, err := buildHandshakeV10(connID)
+// sendHandshake writes the server greeting and returns the scramble it advertised, which
+// the caller must retain to make sense of the client's auth reply.
+func sendHandshake(w io.Writer, connID uint32) ([]byte, error) {
+	greeting, scramble, err := buildHandshakeV10(connID)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return writePacket(w, 0, greeting)
+	if err := writePacket(w, 0, greeting); err != nil {
+		return nil, err
+	}
+	return scramble, nil
+}
+
+// nativePasswordArtifact renders a captured mysql_native_password exchange in hashcat's
+// -m 11200 format ("$mysqlna$<scramble>*<response>").
+//
+// The tagged format is deliberate. This value lands in attackers.password, a column that
+// holds plaintext for ssh/telnet/postgres, so an untagged 40-hex blob would eventually be
+// read as a password someone actually typed. The $mysqlna$ prefix says what it is, and it
+// is the format a cracker consumes without conversion.
+//
+// Returns empty unless both halves are exactly 20 bytes: an empty reply is an anonymous
+// login rather than a credential, and any other length means the client negotiated a
+// different auth plugin, where this format would misdescribe what we captured.
+func nativePasswordArtifact(scramble, authData []byte) string {
+	if len(scramble) != 20 || len(authData) != 20 {
+		return ""
+	}
+	return "$mysqlna$" + hex.EncodeToString(scramble) + "*" + hex.EncodeToString(authData)
 }

--- a/mysql/handshake.go
+++ b/mysql/handshake.go
@@ -205,6 +205,13 @@ func nativePasswordArtifact(scramble, authData []byte, authPlugin string) string
 	if len(scramble) != 20 || len(authData) != 20 {
 		return ""
 	}
+	// An empty plugin name means the client named none, which under the protocol means it
+	// used the plugin the server advertised -- and the greeting only ever advertises
+	// mysql_native_password. Treating it as native is therefore the protocol-correct read,
+	// not a permissive fallback. It does mean a client that omits CLIENT_PLUGIN_AUTH and
+	// sends 20 bytes of something else is taken at its word, which is the same trust any
+	// real server extends; if the advertised plugin ever changes (threat_gg-dpk), this
+	// default must change with it.
 	if authPlugin != "" && authPlugin != authPluginName {
 		return ""
 	}

--- a/mysql/handshake.go
+++ b/mysql/handshake.go
@@ -31,6 +31,12 @@ type credentials struct {
 	username string
 	database string
 	authData []byte
+	// authPlugin is the plugin the client says it used, when it advertised
+	// CLIENT_PLUGIN_AUTH. Empty means it named none. It decides whether authData may be
+	// labelled a mysql_native_password hash: a 20-byte reply proves nothing on its own,
+	// and a mysql_clear_password reply of that length is a plaintext password that must
+	// never be stored as though it were a digest.
+	authPlugin string
 }
 
 // buildHandshakeV10 constructs the server greeting packet and returns the per-connection
@@ -107,7 +113,7 @@ func parseHandshakeResponse(payload []byte) credentials {
 	offset := 0
 
 	// Capability flags (4 bytes)
-	_ = binary.LittleEndian.Uint32(payload[offset:])
+	capFlags := binary.LittleEndian.Uint32(payload[offset:])
 	offset += 4
 
 	// Max packet size (4 bytes)
@@ -141,14 +147,29 @@ func parseHandshakeResponse(payload []byte) credentials {
 		offset += authLen
 	}
 
-	// Database (null-terminated, optional)
-	if offset < len(payload) {
+	// Database (null-terminated, present only when the client asked to connect with one).
+	// The flag is honoured rather than assumed because the auth plugin name follows, and
+	// reading the database when there is none would consume it.
+	if capFlags&clientConnectWithDB != 0 && offset < len(payload) {
 		dbEnd := offset
 		for dbEnd < len(payload) && payload[dbEnd] != 0x00 {
 			dbEnd++
 		}
 		if dbEnd > offset {
 			creds.database = string(payload[offset:dbEnd])
+		}
+		offset = dbEnd + 1
+	}
+
+	// Auth plugin name (null-terminated, present only when the client advertised
+	// CLIENT_PLUGIN_AUTH).
+	if capFlags&clientPluginAuth != 0 && offset < len(payload) {
+		pluginEnd := offset
+		for pluginEnd < len(payload) && payload[pluginEnd] != 0x00 {
+			pluginEnd++
+		}
+		if pluginEnd > offset {
+			creds.authPlugin = string(payload[offset:pluginEnd])
 		}
 	}
 
@@ -176,11 +197,15 @@ func sendHandshake(w io.Writer, connID uint32) ([]byte, error) {
 // read as a password someone actually typed. The $mysqlna$ prefix says what it is, and it
 // is the format a cracker consumes without conversion.
 //
-// Returns empty unless both halves are exactly 20 bytes: an empty reply is an anonymous
-// login rather than a credential, and any other length means the client negotiated a
-// different auth plugin, where this format would misdescribe what we captured.
-func nativePasswordArtifact(scramble, authData []byte) string {
+// Returns empty unless both halves are exactly 20 bytes AND the client either named
+// mysql_native_password or named no plugin at all. Length alone is not proof: a
+// mysql_clear_password reply that happens to be 20 bytes is a plaintext password, and
+// hex-encoding it under a $mysqlna$ label would both misdescribe it and bury it.
+func nativePasswordArtifact(scramble, authData []byte, authPlugin string) string {
 	if len(scramble) != 20 || len(authData) != 20 {
+		return ""
+	}
+	if authPlugin != "" && authPlugin != authPluginName {
 		return ""
 	}
 	return "$mysqlna$" + hex.EncodeToString(scramble) + "*" + hex.EncodeToString(authData)

--- a/mysql/handshake.go
+++ b/mysql/handshake.go
@@ -155,9 +155,8 @@ func parseHandshakeResponse(payload []byte) credentials {
 	return creds
 }
 
-// sendHandshake writes the HandshakeV10 greeting to the connection.
-// sendHandshake writes the server greeting and returns the scramble it advertised, which
-// the caller must retain to make sense of the client's auth reply.
+// sendHandshake writes the HandshakeV10 greeting and returns the scramble it advertised,
+// which the caller must retain to make sense of the client's auth reply.
 func sendHandshake(w io.Writer, connID uint32) ([]byte, error) {
 	greeting, scramble, err := buildHandshakeV10(connID)
 	if err != nil {

--- a/mysql/handshake_test.go
+++ b/mysql/handshake_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBuildHandshakeV10(t *testing.T) {
-	pkt, err := buildHandshakeV10(42)
+	pkt, _, err := buildHandshakeV10(42)
 	if err != nil {
 		t.Fatalf("buildHandshakeV10 failed: %v", err)
 	}
@@ -36,8 +36,8 @@ func TestBuildHandshakeV10(t *testing.T) {
 }
 
 func TestBuildHandshakeV10_ScrambleLength(t *testing.T) {
-	pkt1, _ := buildHandshakeV10(1)
-	pkt2, _ := buildHandshakeV10(2)
+	pkt1, _, _ := buildHandshakeV10(1)
+	pkt2, _, _ := buildHandshakeV10(2)
 
 	// Two calls should produce different scramble data (random)
 	// Find scramble part 1 location (after connID, 4 bytes)
@@ -134,7 +134,7 @@ func TestParseHandshakeResponse_NoDatabase(t *testing.T) {
 
 func TestSendHandshake(t *testing.T) {
 	var buf bytes.Buffer
-	err := sendHandshake(&buf, 100)
+	_, err := sendHandshake(&buf, 100)
 	if err != nil {
 		t.Fatalf("sendHandshake failed: %v", err)
 	}

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -16,12 +16,15 @@ import (
 )
 
 const (
+	// maxCommands bounds how many commands one session may issue before the honeypot stops
+	// reading, so a single connection cannot buffer captured queries without limit.
 	maxCommands = 500
 	// maxConsecutivePersistFailures bounds how long a session's persistence goroutine will
 	// keep trying against an unresponsive backend. See the loop in persistSession.
 	maxConsecutivePersistFailures = 3
-	totalTimeout                  = 300 * time.Second
-	idleTimeout                   = 30 * time.Second
+	// totalTimeout caps a whole session; idleTimeout caps the wait for each next command.
+	totalTimeout = 300 * time.Second
+	idleTimeout  = 30 * time.Second
 )
 
 var _ honeypots.Honeypot = &honeypot{}
@@ -205,11 +208,11 @@ commandLoop:
 	// persistSession runs from the deferred call above, which covers this exit too.
 }
 
-// persistSession records the login and then every query the session issued. It skips
-// sessions that produced neither a username nor a query, so an ordinary port scan that
-// opens a connection and leaves does not manufacture an attacker row; a session with only
-// one of the two is still recorded, since an unauthenticated query and a credential with
-// no follow-up are both worth keeping.
+// persistSession records the login and then every query the session issued. It skips only
+// sessions that produced nothing at all -- no username, no credential, no query -- so an
+// ordinary port scan that opens a connection and leaves does not manufacture an attacker
+// row. Any one of the three is enough to record: an unauthenticated query, a credential
+// with no follow-up, and an anonymous login are all worth keeping.
 //
 // Order matters and is not incidental: the server materializes the attacker row from the
 // login, and SaveQuery only writes an attacker_commands row keyed by the same guid. Saving
@@ -217,7 +220,11 @@ commandLoop:
 // never appears in attackers, so they would be invisible in the dashboard rather than
 // merely late. That is why a login error returns instead of pressing on.
 func (h *honeypot) persistSession(sess *session) {
-	if len(sess.queries) == 0 && sess.username == "" {
+	// authData is part of the test because MySQL allows anonymous accounts: a client can
+	// authenticate with an empty username and still send a real native-password response.
+	// Checking only the username and queries discarded exactly that -- a captured
+	// credential, thrown away for want of a name to file it under.
+	if len(sess.queries) == 0 && sess.username == "" && len(sess.authData) == 0 {
 		return
 	}
 

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -16,9 +16,12 @@ import (
 )
 
 const (
-	maxCommands  = 500
-	totalTimeout = 300 * time.Second
-	idleTimeout  = 30 * time.Second
+	maxCommands = 500
+	// maxConsecutivePersistFailures bounds how long a session's persistence goroutine will
+	// keep trying against an unresponsive backend. See the loop in persistSession.
+	maxConsecutivePersistFailures = 3
+	totalTimeout                  = 300 * time.Second
+	idleTimeout                   = 30 * time.Second
 )
 
 var _ honeypots.Honeypot = &honeypot{}
@@ -72,8 +75,9 @@ type session struct {
 	queries  []string
 	// scramble and authData are the two halves of the mysql_native_password exchange.
 	// Both are needed to produce a crackable artifact; see nativePasswordArtifact.
-	scramble []byte
-	authData []byte
+	scramble   []byte
+	authData   []byte
+	authPlugin string
 }
 
 func (h *honeypot) handleConnection(conn net.Conn) {
@@ -115,6 +119,7 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	sess.username = creds.username
 	sess.database = creds.database
 	sess.authData = creds.authData
+	sess.authPlugin = creds.authPlugin
 
 	h.logger.Info().
 		Str("session", sess.guid).
@@ -218,7 +223,7 @@ func (h *honeypot) persistSession(sess *session) {
 		RemoteAddr: sess.remoteIP,
 		Guid:       sess.guid,
 		Username:   sess.username,
-		Password:   nativePasswordArtifact(sess.scramble, sess.authData),
+		Password:   nativePasswordArtifact(sess.scramble, sess.authData, sess.authPlugin),
 	}
 	if err := saveMysqlLogin(req); err != nil {
 		h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist mysql login")
@@ -231,14 +236,30 @@ func (h *honeypot) persistSession(sess *session) {
 	// response server -- isSensitiveMySQLLookup drops anything containing "identified by",
 	// "set password" or "password(" -- which used to mean the statements most worth having
 	// were the ones guaranteed to be recorded nowhere.
-	for _, query := range sess.queries {
+	// A single failure is transient and must not cost the rest of the session -- the
+	// statement worth having is as likely to be last as first. A run of them means the
+	// backend is down, and grinding through the remaining queries would hold this
+	// goroutine, and the session's captured payloads, for maxCommands * saveTimeout
+	// (~42 minutes at 500 x 5s) while succeeding at nothing. Give up after a few.
+	consecutiveFailures := 0
+	for i, query := range sess.queries {
 		if err := saveQuery(&proto.QueryRequest{
 			Guid:        sess.guid,
 			Query:       query,
 			CommandType: "mysql",
 		}); err != nil {
 			h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist mysql query")
+			consecutiveFailures++
+			if consecutiveFailures >= maxConsecutivePersistFailures {
+				h.logger.Error().
+					Str("session", sess.guid).
+					Int("abandoned", len(sess.queries)-i-1).
+					Msg("abandoning mysql query persistence; backend appears unavailable")
+				return
+			}
+			continue
 		}
+		consecutiveFailures = 0
 	}
 }
 

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -128,6 +128,7 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	}
 
 	// Command phase
+commandLoop:
 	for i := 0; i < maxCommands; i++ {
 		conn.SetReadDeadline(time.Now().Add(idleTimeout))
 
@@ -168,7 +169,11 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 			cmdErr = handleComStatistics(conn, seqID+1)
 
 		case comQuit:
-			return
+			// Break the loop rather than return: returning skipped persistSession below,
+			// so a client that disconnected politely -- which every real MySQL driver
+			// does -- had its entire session discarded, credentials and queries alike.
+			// The best-behaved sessions were the ones we dropped.
+			break commandLoop
 
 		default:
 			// Unknown command: return OK

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -23,6 +23,12 @@ const (
 
 var _ honeypots.Honeypot = &honeypot{}
 
+// Indirected for tests, matching the mssql package.
+var (
+	saveMysqlLogin = persistence.SaveMysqlLogin
+	saveQuery      = persistence.SaveQuery
+)
+
 type honeypot struct {
 	logger zerolog.Logger
 }
@@ -64,6 +70,10 @@ type session struct {
 	database string
 	remoteIP string
 	queries  []string
+	// scramble and authData are the two halves of the mysql_native_password exchange.
+	// Both are needed to produce a crackable artifact; see nativePasswordArtifact.
+	scramble []byte
+	authData []byte
 }
 
 func (h *honeypot) handleConnection(conn net.Conn) {
@@ -86,10 +96,12 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	connID := rand.Uint32()
 
 	// Send server greeting
-	if err := sendHandshake(conn, connID); err != nil {
+	scramble, err := sendHandshake(conn, connID)
+	if err != nil {
 		h.logger.Debug().Err(err).Msg("failed to send handshake")
 		return
 	}
+	sess.scramble = scramble
 
 	// Read client auth response
 	reader := bufio.NewReader(conn)
@@ -102,6 +114,7 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	creds := parseHandshakeResponse(payload)
 	sess.username = creds.username
 	sess.database = creds.database
+	sess.authData = creds.authData
 
 	h.logger.Info().
 		Str("session", sess.guid).
@@ -175,6 +188,13 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	go h.persistSession(sess)
 }
 
+// persistSession records the login and then every query the session issued.
+//
+// Order matters and is not incidental: the server materializes the attacker row from the
+// login, and SaveQuery only writes an attacker_commands row keyed by the same guid. Saving
+// queries first (or after a failed login) would leave commands pointing at a guid that
+// never appears in attackers, so they would be invisible in the dashboard rather than
+// merely late. That is why a login error returns instead of pressing on.
 func (h *honeypot) persistSession(sess *session) {
 	if len(sess.queries) == 0 && sess.username == "" {
 		return
@@ -184,13 +204,27 @@ func (h *honeypot) persistSession(sess *session) {
 		RemoteAddr: sess.remoteIP,
 		Guid:       sess.guid,
 		Username:   sess.username,
-		Password:   "",
+		Password:   nativePasswordArtifact(sess.scramble, sess.authData),
 	}
-	if err := persistence.SaveMysqlLogin(req); err != nil {
+	if err := saveMysqlLogin(req); err != nil {
 		h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist mysql login")
 		return
 	}
 
+	// Queries are saved here rather than inline in the command loop so they cannot outrun
+	// the login above. Capture is deliberately independent of the cmdresp override lookup:
+	// that path skips credential-bearing statements (isSensitiveMySQLLookup) to avoid
+	// forwarding secrets to the response server, which used to mean CREATE USER ...
+	// IDENTIFIED BY was the one statement guaranteed to be recorded nowhere.
+	for _, query := range sess.queries {
+		if err := saveQuery(&proto.QueryRequest{
+			Guid:        sess.guid,
+			Query:       query,
+			CommandType: "mysql",
+		}); err != nil {
+			h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist mysql query")
+		}
+	}
 }
 
 func truncate(s string, maxLen int) string {

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -122,6 +122,12 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 		Str("database", creds.database).
 		Msg("auth received")
 
+	// From here on the credential is captured, so every exit must run persistSession.
+	// A bare return would lose it exactly where it is most valuable: a credential-spraying
+	// scanner sends its auth response and closes without waiting for the reply, which is
+	// precisely when writing the OK packet fails. Same family as the COM_QUIT case below.
+	defer func() { go h.persistSession(sess) }()
+
 	// Send OK (auth success)
 	if err := writeOKPacket(conn, 2, 0, 0); err != nil {
 		return
@@ -189,11 +195,14 @@ commandLoop:
 		Str("session", sess.guid).
 		Int("queries", len(sess.queries)).
 		Msg("session ended")
-
-	go h.persistSession(sess)
+	// persistSession runs from the deferred call above, which covers this exit too.
 }
 
-// persistSession records the login and then every query the session issued.
+// persistSession records the login and then every query the session issued. It skips
+// sessions that produced neither a username nor a query, so an ordinary port scan that
+// opens a connection and leaves does not manufacture an attacker row; a session with only
+// one of the two is still recorded, since an unauthenticated query and a credential with
+// no follow-up are both worth keeping.
 //
 // Order matters and is not incidental: the server materializes the attacker row from the
 // login, and SaveQuery only writes an attacker_commands row keyed by the same guid. Saving
@@ -218,9 +227,10 @@ func (h *honeypot) persistSession(sess *session) {
 
 	// Queries are saved here rather than inline in the command loop so they cannot outrun
 	// the login above. Capture is deliberately independent of the cmdresp override lookup:
-	// that path skips credential-bearing statements (isSensitiveMySQLLookup) to avoid
-	// forwarding secrets to the response server, which used to mean CREATE USER ...
-	// IDENTIFIED BY was the one statement guaranteed to be recorded nowhere.
+	// that path skips credential-bearing statements to avoid forwarding secrets to the
+	// response server -- isSensitiveMySQLLookup drops anything containing "identified by",
+	// "set password" or "password(" -- which used to mean the statements most worth having
+	// were the ones guaranteed to be recorded nowhere.
 	for _, query := range sess.queries {
 		if err := saveQuery(&proto.QueryRequest{
 			Guid:        sess.guid,

--- a/mysql/mysql.go
+++ b/mysql/mysql.go
@@ -75,8 +75,10 @@ type session struct {
 	queries  []string
 	// scramble and authData are the two halves of the mysql_native_password exchange.
 	// Both are needed to produce a crackable artifact; see nativePasswordArtifact.
-	scramble   []byte
-	authData   []byte
+	scramble []byte
+	authData []byte
+	// authPlugin is the plugin the client named, and it decides whether the pair above may
+	// be labelled a native-password digest at all. See nativePasswordArtifact.
 	authPlugin string
 }
 

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -141,8 +141,16 @@ func SaveKafkaApiRequest(in *proto.KafkaApiRequest) error {
 	return err
 }
 
+// SaveMysqlLogin is deadline-bounded because the mysql session persists its queries only
+// after this call returns (see mysql.persistSession): on a stalled backend an unbounded
+// call would strand the whole session's capture, not just the login, and leak the
+// goroutine with it.
 func SaveMysqlLogin(in *proto.MysqlRequest) error {
-	ctx := context.Background()
+	if honeypotClient == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), saveTimeout)
+	defer cancel()
 	ctx = metadata.NewOutgoingContext(ctx, connMetadata)
 	_, err := honeypotClient.SaveMysqlLogin(ctx, in)
 	return err

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -189,6 +189,14 @@ func TestSaveLmstudioRequestIsNoOpWithoutClient(t *testing.T) {
 	require.NoError(t, SaveLmstudioRequest(&proto.LlmRequest{}))
 }
 
+func TestSaveMysqlCallsAreNoOpWithoutClient(t *testing.T) {
+	originalClient := honeypotClient
+	t.Cleanup(func() { honeypotClient = originalClient })
+	honeypotClient = nil
+	require.NoError(t, SaveMysqlLogin(&proto.MysqlRequest{}))
+	require.NoError(t, SaveQuery(&proto.QueryRequest{CommandType: "mysql"}))
+}
+
 func TestSaveMssqlCallsAreNoOpWithoutClient(t *testing.T) {
 	originalClient := honeypotClient
 	t.Cleanup(func() { honeypotClient = originalClient })

--- a/persistence/persistence_test.go
+++ b/persistence/persistence_test.go
@@ -89,6 +89,11 @@ func (blockingClient) SaveMssqlLogin(ctx context.Context, in *proto.MssqlRequest
 	return nil, ctx.Err()
 }
 
+func (blockingClient) SaveMysqlLogin(ctx context.Context, in *proto.MysqlRequest, opts ...grpc.CallOption) (*proto.SaveReply, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
 func (blockingClient) SaveKubeletRequest(ctx context.Context, in *proto.KubeletRequest, opts ...grpc.CallOption) (*proto.SaveReply, error) {
 	<-ctx.Done()
 	return nil, ctx.Err()
@@ -139,6 +144,9 @@ func TestAsynchronousSaveCallsAreTimeBounded(t *testing.T) {
 		{"s3", func() error { return SaveS3Request(&proto.S3Request{}) }},
 		{"lmstudio", func() error { return SaveLmstudioRequest(&proto.LlmRequest{}) }},
 		{"mssql-login", func() error { return SaveMssqlLogin(&proto.MssqlRequest{}) }},
+		// mysql-login is load-bearing: mysql.persistSession saves the session's queries
+		// only after this returns, so an unbounded call strands the whole capture.
+		{"mysql-login", func() error { return SaveMysqlLogin(&proto.MysqlRequest{}) }},
 		{"kubelet", func() error { return SaveKubeletRequest(&proto.KubeletRequest{}) }},
 		{"consul", func() error { return SaveConsulRequest(&proto.ConsulRequest{}) }},
 		{"amqp", func() error { return SaveAmqpSession(&proto.AmqpSessionRequest{}) }},


### PR DESCRIPTION
Closes `threat_gg-cb0`.

## The bug

The MySQL honeypot parsed the client's auth response and every query, then discarded both. `persistSession` hardcoded `Password: ""` while `sess.queries` was only ever counted for a log line — there was no query-save path at all.

Production confirms it: since Aug 2 MySQL captured **68 usernames and 0 passwords**, against 2,320 for mssql and 2,568 for postgres.

## Credential capture needs both halves

`mysql_native_password` replies with `SHA1(pw) XOR SHA1(scramble || SHA1(SHA1(pw)))`. The client's 20 bytes are **uncrackable without the server scramble** — which `buildHandshakeV10` generated and then threw away. So capturing `authData` alone (the obvious fix) would have produced a useless artifact.

`buildHandshakeV10`/`sendHandshake` now return the scramble, the session retains it, and the pair is stored in hashcat's **`-m 11200`** format: `$mysqlna$<scramble>*<response>`.

The `$mysqlna$` tag is deliberate — `attackers.password` holds *plaintext* for ssh/telnet/postgres, so an untagged 40-hex blob would eventually be read as a password someone actually typed. It's emitted only when both halves are exactly 20 bytes, so an anonymous login (empty reply) or a different auth plugin (`caching_sha2_password`) is never misdescribed.

## Query capture needs no server change

Reuses the existing generic `SaveQuery` RPC with `command_type: "mysql"`:
- the server **already accepts** it — `grpc_server/server.go:862`
- the server **already renders** it — `mysql` is in `allowedAttackTypes` and is an `ArchetypeCredentialedSession`, so `supportsCommandHistory` fetches its `attacker_commands`
- `mssql/mssql.go:159` set the precedent

So **no proto, server, migration or frontend change** is required, and no deploy ordering constraint.

Capture is deliberately independent of the `cmdresp` override lookup. That path's `isSensitiveMySQLLookup` gate skips `identified by` / `set password` / `password(` to avoid forwarding secrets to the response server — sensible, but with no other path it made `CREATE USER ... IDENTIFIED BY` the one statement guaranteed to be recorded nowhere. A test pins that statement specifically.

## Ordering

Queries are saved *after* the login, not inline. The server materializes the attacker row from the login, and `SaveQuery` only writes an `attacker_commands` row keyed by the same guid — commands that outran it would reference a guid absent from `attackers` and be **invisible**, not merely late. A login error therefore returns instead of pressing on, and there's a test for it.

## Notes for review

- **Top-credentials pollution — considered, not a problem.** `AdminTopCredentials` groups by `(username, password)` across all attack types with no filter. Because each scramble is random per connection, every artifact is unique, so they always have `count = 1` and can never displace the real repeats (`root`/`123456`, thousands of hits). No filter added.
- `attackers.password` is `character varying` with no length limit; the artifact is 90 chars. No truncation.
- Existing handshake tests updated for the new signatures.
- Session-persistence semantics are unchanged: a bare connection that sends no auth still records nothing.

## Verification

`gofmt` clean, `go vet` clean, full suite **39 packages passing**. New tests cover the artifact format, the four unusable-input cases, per-connection scramble uniqueness, the full persist path, the orphan-prevention guard, empty sessions, and anonymous logins.

## Out of scope

The handshake fidelity problems that may explain the low session count in the first place (claims 8.0.35 but advertises `mysql_native_password`, charset 45, and an impossible capability word) are tracked separately in **`threat_gg-dpk`**. If those are fixed to use `caching_sha2_password`, this credential path will need a matching artifact format for that plugin — the length guard means it degrades to "no credential" rather than to a wrong one in the meantime.
