### PR TITLE
fix(redis): persist sessions that end in QUIT (threat_gg-vz7m)

### DIFF
--- a/redis/capture_test.go
+++ b/redis/capture_test.go
@@ -1,0 +1,175 @@
+package redis
+
+import (
+	"bufio"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joshrendek/threat.gg-agent/proto"
+	"github.com/rs/zerolog"
+)
+
+// threat_gg-vz7m. The QUIT case returned straight out of handleConnection, skipping the
+// persistSession call at the bottom of the function. Every client that disconnected
+// politely -- redis-cli and effectively every real client library send QUIT on close --
+// had its entire session discarded: commands, credentials, all of it. Only sessions that
+// timed out, errored, or hit the command cap were ever persisted, so the honeypot was
+// keeping the abrupt scans and dropping the well-behaved tooling.
+//
+// Same bug class as the two found in mysql (threat_gg-cb0), and the reason these tests
+// drive a real connection: a unit test that builds a session by hand cannot see it.
+
+type recorder struct {
+	mu       sync.Mutex
+	connects []*proto.RedisConnectRequest
+	commands []*proto.RedisCommandRequest
+}
+
+func (r *recorder) connect(in *proto.RedisConnectRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.connects = append(r.connects, in)
+	return nil
+}
+
+func (r *recorder) command(in *proto.RedisCommandRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.commands = append(r.commands, in)
+	return nil
+}
+
+func withRecorder(t *testing.T) *recorder {
+	t.Helper()
+	rec := &recorder{}
+	origConnect, origCommand := saveRedisConnect, saveRedisCommand
+	saveRedisConnect, saveRedisCommand = rec.connect, rec.command
+	t.Cleanup(func() { saveRedisConnect, saveRedisCommand = origConnect, origCommand })
+	return rec
+}
+
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// runSession drives a connection through the honeypot, sending each inline command and
+// reading whatever comes back, then waits for the handler to finish.
+func runSession(t *testing.T, commands ...string) *recorder {
+	t.Helper()
+	rec := withRecorder(t)
+	done := make(chan struct{})
+
+	server, client := net.Pipe()
+	h := &honeypot{logger: zerolog.Nop()}
+	go func() {
+		h.handleConnection(server)
+		close(done)
+	}()
+
+	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+	// Drain concurrently: replies are unread otherwise and net.Pipe is unbuffered, so the
+	// handler would block writing instead of reaching the next command.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := client.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	writer := bufio.NewWriter(client)
+	for _, cmd := range commands {
+		if _, err := writer.WriteString(cmd + "\r\n"); err != nil {
+			t.Fatalf("write %q: %v", cmd, err)
+		}
+		if err := writer.Flush(); err != nil {
+			t.Fatalf("flush %q: %v", cmd, err)
+		}
+	}
+
+	// Hang up. A session ended by QUIT has already returned by now; one that was not needs
+	// the disconnect, otherwise the handler sits waiting for the next command until its
+	// idle timeout.
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleConnection did not return")
+	}
+	return rec
+}
+
+// TestSessionEndingInQuitIsPersisted is the regression: QUIT is the polite disconnect, so
+// it must not be the one path that discards the session.
+func TestSessionEndingInQuitIsPersisted(t *testing.T) {
+	rec := runSession(t, "AUTH hunter2", "SET foo bar", "QUIT")
+
+	waitFor(t, func() bool {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		return len(rec.connects) == 1
+	}, "the QUIT session to be persisted")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.connects) != 1 {
+		t.Fatalf("connects = %d, want 1", len(rec.connects))
+	}
+	if rec.connects[0].Password != "hunter2" {
+		t.Errorf("password = %q, want hunter2; the credential must survive a polite disconnect",
+			rec.connects[0].Password)
+	}
+	// AUTH, SET and QUIT are all recorded before dispatch, so all three should persist.
+	if len(rec.commands) != 3 {
+		t.Fatalf("commands = %d, want 3", len(rec.commands))
+	}
+	for i, c := range rec.commands {
+		if c.Guid != rec.connects[0].Guid {
+			t.Errorf("command %d guid %q does not match the connect guid %q", i, c.Guid, rec.connects[0].Guid)
+		}
+	}
+	if rec.commands[1].Command != "SET foo bar" {
+		t.Errorf("command 1 = %q, want %q", rec.commands[1].Command, "SET foo bar")
+	}
+}
+
+// A session that ends by disconnecting rather than by QUIT already worked; this pins it so
+// the fix does not trade one path for the other.
+func TestSessionEndingInDisconnectIsPersisted(t *testing.T) {
+	rec := runSession(t, "SET foo bar")
+
+	waitFor(t, func() bool {
+		rec.mu.Lock()
+		defer rec.mu.Unlock()
+		return len(rec.connects) == 1
+	}, "the disconnected session to be persisted")
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.commands) != 1 || rec.commands[0].Command != "SET foo bar" {
+		t.Errorf("commands = %+v, want one SET foo bar", rec.commands)
+	}
+}
+
+// A bare connection that issues nothing must not manufacture an attacker row.
+func TestConnectionWithNoCommandsPersistsNothing(t *testing.T) {
+	rec := runSession(t)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.connects) != 0 || len(rec.commands) != 0 {
+		t.Errorf("bare connection persisted %d connects, %d commands", len(rec.connects), len(rec.commands))
+	}
+}

--- a/redis/capture_test.go
+++ b/redis/capture_test.go
@@ -77,6 +77,9 @@ func runSession(t *testing.T, commands ...string) *recorder {
 	}()
 
 	_ = client.SetDeadline(time.Now().Add(10 * time.Second))
+	// Registered before the drain goroutine starts so a t.Fatalf below cannot strand it:
+	// closing the pipe is what makes its blocked Read return.
+	t.Cleanup(func() { client.Close() })
 	// Drain concurrently: replies are unread otherwise and net.Pipe is unbuffered, so the
 	// handler would block writing instead of reaching the next command.
 	go func() {
@@ -116,11 +119,15 @@ func runSession(t *testing.T, commands ...string) *recorder {
 func TestSessionEndingInQuitIsPersisted(t *testing.T) {
 	rec := runSession(t, "AUTH hunter2", "SET foo bar", "QUIT")
 
+	// Wait for the COMPLETE expected state, not just the connect. persistSession saves the
+	// connect first and then reads saveRedisCommand once per command, so returning early
+	// would let the test's cleanup restore those vars while the goroutine still reads them.
+	// The recorder's mutex is what gives us the happens-before edge.
 	waitFor(t, func() bool {
 		rec.mu.Lock()
 		defer rec.mu.Unlock()
-		return len(rec.connects) == 1
-	}, "the QUIT session to be persisted")
+		return len(rec.connects) == 1 && len(rec.commands) == 3
+	}, "the QUIT session and all three commands to be persisted")
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
@@ -153,8 +160,8 @@ func TestSessionEndingInDisconnectIsPersisted(t *testing.T) {
 	waitFor(t, func() bool {
 		rec.mu.Lock()
 		defer rec.mu.Unlock()
-		return len(rec.connects) == 1
-	}, "the disconnected session to be persisted")
+		return len(rec.connects) == 1 && len(rec.commands) == 1
+	}, "the disconnected session and its command to be persisted")
 
 	rec.mu.Lock()
 	defer rec.mu.Unlock()

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -29,6 +29,12 @@ const (
 // miss/error paths are unit-testable without a live server.
 var getCommandResponse = persistence.GetCommandResponse
 
+// Indirected for tests, matching the mysql and mssql packages.
+var (
+	saveRedisConnect = persistence.SaveRedisConnect
+	saveRedisCommand = persistence.SaveRedisCommand
+)
+
 // serverResponse writes an admin-authored redis response VERBATIM to w when the server has
 // a Matched row for (command_type="redis", payload=fullCmd). RESP is line-oriented text, so
 // the stored response is exact RESP frames authored by the admin (e.g. "+PONG\r\n",
@@ -119,6 +125,14 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 	}
 
 	h.logger.Info().Str("session", sess.guid).Str("remote", remoteAddr).Msg("new connection")
+
+	// Deferred so that every exit persists, including the QUIT case in the command loop.
+	// QUIT used to return straight out of this function and skip persistence entirely, so
+	// a client that disconnected politely -- redis-cli and effectively every real client
+	// library send QUIT on close -- had its whole session discarded, commands and
+	// credentials alike. The better behaved the client, the more certain the loss.
+	// persistSession itself declines to record a session that issued nothing.
+	defer func() { go h.persistSession(sess) }()
 
 	conn.SetDeadline(time.Now().Add(totalTimeout))
 
@@ -237,7 +251,7 @@ func (h *honeypot) handleConnection(conn net.Conn) {
 		Int("commands", len(sess.commands)).
 		Msg("session ended")
 
-	go h.persistSession(sess)
+	// persistSession runs from the deferred call above, which covers this exit too.
 }
 
 func handleError(conn net.Conn, msg string) error {
@@ -255,7 +269,7 @@ func (h *honeypot) persistSession(sess *session) {
 		Username:   sess.username,
 		Password:   sess.password,
 	}
-	if err := persistence.SaveRedisConnect(req); err != nil {
+	if err := saveRedisConnect(req); err != nil {
 		h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist redis connect")
 		return
 	}
@@ -265,7 +279,7 @@ func (h *honeypot) persistSession(sess *session) {
 			Guid:    sess.guid,
 			Command: cmd,
 		}
-		if err := persistence.SaveRedisCommand(cmdReq); err != nil {
+		if err := saveRedisCommand(cmdReq); err != nil {
 			h.logger.Error().Err(err).Str("session", sess.guid).Msg("failed to persist redis command")
 		}
 	}


### PR DESCRIPTION
Closes `threat_gg-vz7m`.

## The bug

`redis/redis.go` — the `QUIT` case returned straight out of `handleConnection`, skipping the `persistSession` call at the bottom:

```go
case "QUIT":
    handleQuit(conn)
    return          // ← skipped persistSession entirely
```

Every client that disconnected politely — `redis-cli` and effectively every real client library send `QUIT` on close — had its **whole session discarded**: commands, credentials, all of it. Only sessions that timed out, errored, or hit the command cap were ever persisted.

The severity is perverse: **the better-behaved the client, the more certain the loss.** We were keeping abrupt scan noise and dropping the interactive tooling worth more.

Prod context: redis shows 5,004 sessions / 909 IPs / 24,724 commands since Aug 2, so capture was not dead — we were silently losing whatever share uses a real client library.

## The fix

Persistence runs from a deferred call placed as soon as the session exists, so no future early return can reintroduce it. `persistSession` still declines a session that issued nothing.

## Why the tests look like this

A unit test that builds a `session` by hand **cannot catch this** — that is exactly how it survived in mysql. So the tests drive a real connection over `net.Pipe`:

| Test | Pins |
|---|---|
| `TestSessionEndingInQuitIsPersisted` | the regression: AUTH credential + commands survive a polite disconnect |
| `TestSessionEndingInDisconnectIsPersisted` | the path that already worked, so the fix cannot trade one for the other |
| `TestConnectionWithNoCommandsPersistsNothing` | a bare connection still does not manufacture an attacker row |

`SaveRedisConnect`/`SaveRedisCommand` are indirected behind package vars — the same seam `mysql` and `mssql` already use — so the tests can observe persistence without a live server.

**Verified by mutation**: restoring the bare `return` fails the QUIT test; with the fix it passes.

## Provenance

Found by generalising the same bug class from mysql (`threat_gg-cb0`), which had two instances of it. I audited the rest of the fleet while here:

- `mongo`, `mqtt` — already use this defer shape ✅
- `vnc`, `rdp`, `smtp`, `smb` — no early return between capture and persist ✅
- `kafka` — calls `persistSession` bare but has no early return before it today; safe, though one refactor from the same trap

## Verification

gofmt, `go vet` and the full suite (39 packages) pass; `redis` also passes `-race`.
